### PR TITLE
Fix links not being made clickable from html

### DIFF
--- a/commet/lib/client/matrix/matrix_timeline_event.dart
+++ b/commet/lib/client/matrix/matrix_timeline_event.dart
@@ -8,7 +8,6 @@ import 'package:commet/client/timeline.dart';
 import 'package:commet/ui/atoms/rich_text/matrix_html_parser.dart';
 import 'package:commet/utils/emoji/unicode_emoji.dart';
 import 'package:commet/utils/mime.dart';
-import 'package:commet/utils/text_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:matrix/matrix.dart' as matrix;

--- a/commet/lib/client/matrix/matrix_timeline_event.dart
+++ b/commet/lib/client/matrix/matrix_timeline_event.dart
@@ -219,7 +219,6 @@ class MatrixTimelineEvent implements TimelineEvent {
     } else {
       bodyFormat = "chat.commet.default";
       formattedBody = body!;
-      formattedBody = TextUtils.linkifyStringHtml(formattedBody!);
     }
 
     formattedContent = MatrixHtmlParser.parse(formattedBody!, client);

--- a/commet/lib/ui/atoms/rich_text/matrix_html_parser.dart
+++ b/commet/lib/ui/atoms/rich_text/matrix_html_parser.dart
@@ -1,6 +1,7 @@
 import 'package:commet/client/matrix/components/emoticon/matrix_emoticon.dart';
 import 'package:commet/ui/atoms/code_block.dart';
 import 'package:commet/ui/atoms/emoji_widget.dart';
+import 'package:commet/ui/atoms/rich_text/spans/link.dart';
 import 'package:commet/utils/emoji/unicode_emoji.dart';
 import 'package:commet/utils/link_utils.dart';
 import 'package:commet/utils/text_utils.dart';
@@ -175,11 +176,20 @@ class CodeHtmlExtension extends HtmlExtension {
 class LinkifyHtmlExtension extends HtmlExtension {
   @override
   InlineSpan build(ExtensionContext context) {
+    if (context.node.attributes.containsKey("href")) {
+      return LinkSpan.create(context.node.text!,
+          destination: Uri.parse(context.node.attributes["href"]!));
+    }
+
     return TextSpan(children: TextUtils.linkifyString(context.node.text!));
   }
 
   @override
   bool matches(ExtensionContext context) {
+    if (context.node.attributes.containsKey("href")) {
+      return true;
+    }
+
     return context.node is dom.Text &&
         TextUtils.containsUrl(context.node.text!);
   }

--- a/commet/lib/ui/atoms/rich_text/matrix_html_parser.dart
+++ b/commet/lib/ui/atoms/rich_text/matrix_html_parser.dart
@@ -14,7 +14,7 @@ import 'package:tiamat/config/style/theme_extensions.dart';
 class MatrixHtmlParser {
   static final CodeBlockHtmlExtension _codeBlock = CodeBlockHtmlExtension();
   static final CodeHtmlExtension _code = CodeHtmlExtension();
-
+  static final LinkifyHtmlExtension _linkify = LinkifyHtmlExtension();
   static Widget parse(String text, matrix.Client client) {
     var document = html_parser.parse(text);
     bool big = shouldDoBigEmoji(document);
@@ -27,6 +27,7 @@ class MatrixHtmlParser {
         extension,
         _codeBlock,
         _code,
+        _linkify,
       ],
       style: {
         "body": Style(
@@ -169,4 +170,20 @@ class CodeHtmlExtension extends HtmlExtension {
 
   @override
   Set<String> get supportedTags => tags;
+}
+
+class LinkifyHtmlExtension extends HtmlExtension {
+  @override
+  InlineSpan build(ExtensionContext context) {
+    return TextSpan(children: TextUtils.linkifyString(context.node.text!));
+  }
+
+  @override
+  bool matches(ExtensionContext context) {
+    return context.node is dom.Text &&
+        TextUtils.containsUrl(context.node.text!);
+  }
+
+  @override
+  Set<String> get supportedTags => {};
 }


### PR DESCRIPTION
After switching to flutter_html, if we were parsing an html doc that contained a link in plaintext, (not in `<a>` tag) then it would not get parsed or made clickable