### PR TITLE
Fix color on read receipts light mode

### DIFF
--- a/commet/lib/ui/molecules/message_input.dart
+++ b/commet/lib/ui/molecules/message_input.dart
@@ -323,6 +323,7 @@ class MessageInputState extends State<MessageInput> {
                           ClipRRect(
                             borderRadius: BorderRadius.circular(4),
                             child: Material(
+                              color: Colors.transparent,
                               child: InkWell(
                                 onTap: widget.onReadReceiptsClicked,
                                 child: Padding(


### PR DESCRIPTION
In light mode, the read receipt indicator had wrong background color