### PR TITLE
Update release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,10 @@ jobs:
           asset_content_type: application/vnd.android.package-archive
 
   release-linux-debian:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -218,7 +221,7 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: commet-pkg/commet-linux-x64.deb
-          asset_name: commet-linux-x64.deb
+          asset_name: commet-${{ matrix.os }}-x64.deb
           asset_content_type: application/vnd.debian.binary-package
 
   release-linux-flatpak:


### PR DESCRIPTION
We will now be releasing two `.deb` files, one for ubuntu 22.04 and one for ubuntu 24.04

The 22.04 version will be using `libmpv1` and the 24.04 version uses `libmpv2`, This should close #103 

The main reason to keep 22.04 around is because some ubuntu derivatives are not updated to 24.04 yet and I wanted to keep support for those. We will probably remove this version eventually