### PR TITLE
Fix horizontal scrolling on overlapping panels

### DIFF
--- a/commet/lib/ui/molecules/overlapping_panels.dart
+++ b/commet/lib/ui/molecules/overlapping_panels.dart
@@ -192,7 +192,6 @@ class OverlappingPanelsState extends State<OverlappingPanels>
     double borderRadius = 20;
 
     return GestureDetector(
-        behavior: HitTestBehavior.deferToChild,
         onHorizontalDragStart: (details) {
           widget.onDragStart?.call();
         },

--- a/commet/lib/ui/molecules/overlapping_panels.dart
+++ b/commet/lib/ui/molecules/overlapping_panels.dart
@@ -191,61 +191,61 @@ class OverlappingPanelsState extends State<OverlappingPanels>
   Widget build(BuildContext context) {
     double borderRadius = 20;
 
-    return Stack(
-      children: [
-        Padding(
-          padding: EdgeInsets.fromLTRB(0, 0, widget.restWidth + 3, 0),
-          child: ClipRRect(
-            borderRadius: BorderRadius.only(
-                topRight: Radius.circular(borderRadius),
-                bottomRight: Radius.circular(borderRadius)),
-            child: Offstage(
-              offstage: translate < 0,
-              child: widget.left,
+    return GestureDetector(
+        behavior: HitTestBehavior.deferToChild,
+        onHorizontalDragStart: (details) {
+          widget.onDragStart?.call();
+        },
+        onHorizontalDragUpdate: (details) {
+          onTranslate(details.delta.dx);
+        },
+        onHorizontalDragEnd: (details) {
+          _onApplyTranslation();
+        },
+        child: Stack(
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(0, 0, widget.restWidth + 3, 0),
+              child: ClipRRect(
+                borderRadius: BorderRadius.only(
+                    topRight: Radius.circular(borderRadius),
+                    bottomRight: Radius.circular(borderRadius)),
+                child: Offstage(
+                  offstage: translate < 0,
+                  child: widget.left,
+                ),
+              ),
             ),
-          ),
-        ),
-        Padding(
-          padding: EdgeInsets.fromLTRB(widget.restWidth + 3, 0, 0, 0),
-          child: ClipRRect(
-            borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(borderRadius),
-                bottomLeft: Radius.circular(borderRadius)),
-            child: Offstage(
-              offstage: translate > 0,
-              child: widget.right,
+            Padding(
+              padding: EdgeInsets.fromLTRB(widget.restWidth + 3, 0, 0, 0),
+              child: ClipRRect(
+                borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(borderRadius),
+                    bottomLeft: Radius.circular(borderRadius)),
+                child: Offstage(
+                  offstage: translate > 0,
+                  child: widget.right,
+                ),
+              ),
             ),
-          ),
-        ),
-        Transform.translate(
-          offset: Offset(translate, 0),
-          child: Container(
-              clipBehavior: Clip.antiAlias,
-              decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(
-                      (translate.abs() * 0.1).clamp(0, 20)),
-                  boxShadow:
-                      Theme.of(context).extension<ShadowSettings>()?.shadows ??
+            Transform.translate(
+              offset: Offset(translate, 0),
+              child: Container(
+                  clipBehavior: Clip.antiAlias,
+                  decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(
+                          (translate.abs() * 0.1).clamp(0, 20)),
+                      boxShadow: Theme.of(context)
+                              .extension<ShadowSettings>()
+                              ?.shadows ??
                           [
                             BoxShadow(
                                 color: Colors.black.withAlpha(30),
                                 blurRadius: 20)
                           ]),
-              child: widget.main),
-        ),
-        GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onHorizontalDragStart: (details) {
-            widget.onDragStart?.call();
-          },
-          onHorizontalDragUpdate: (details) {
-            onTranslate(details.delta.dx);
-          },
-          onHorizontalDragEnd: (details) {
-            _onApplyTranslation();
-          },
-        ),
-      ],
-    );
+                  child: widget.main),
+            )
+          ],
+        ));
   }
 }

--- a/commet/lib/ui/pages/main/main_page_view_mobile.dart
+++ b/commet/lib/ui/pages/main/main_page_view_mobile.dart
@@ -87,18 +87,18 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
         child: Foundation(
             child: OverlappingPanels(
           key: panelsKey,
-          left: navigation(context),
-          main: Foundation(
-              child: IgnorePointer(
-            ignoring: shouldMainIgnoreInput,
-            child: Container(key: mainPanelKey, child: mainPanel()),
-          )),
           onDragStart: () {},
           onSideChange: (side) {
             setState(() {
               shouldMainIgnoreInput = side != RevealSide.main;
             });
           },
+          left: navigation(context),
+          main: Foundation(
+              child: IgnorePointer(
+            ignoring: shouldMainIgnoreInput,
+            child: Container(key: mainPanelKey, child: mainPanel()),
+          )),
           right: rightPanel(context),
         )));
   }


### PR DESCRIPTION
There was an issue where you couldn't horizontally scroll children of overlapping panels due to the gesture detector absorbing the events