### PR TITLE
Jump to specific event in timeline

### DIFF
--- a/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
+++ b/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
@@ -10,7 +10,6 @@ import 'package:commet/ui/molecules/timeline_events/timeline_event_layout.dart';
 import 'package:commet/ui/molecules/timeline_events/timeline_event_menu.dart';
 import 'package:commet/ui/molecules/timeline_events/timeline_view_entry.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class RoomTimelineWidgetView extends StatefulWidget {
   const RoomTimelineWidgetView(

--- a/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_message.dart
+++ b/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_message.dart
@@ -23,8 +23,11 @@ class TimelineEventViewMessage extends StatefulWidget {
       required this.timeline,
       this.isThreadTimeline = false,
       this.overrideShowSender = false,
+      this.jumpToEvent,
       this.detailed = false,
       required this.initialIndex});
+
+  final Function(String eventId)? jumpToEvent;
 
   final Timeline timeline;
   final int initialIndex;
@@ -55,6 +58,7 @@ class _TimelineEventViewMessageState extends State<TimelineEventViewMessage>
   bool hasReactions = false;
   bool isInResponse = false;
   bool showSender = false;
+  late String eventId;
   late String currentUserIdentifier;
   late DateTime sentTime;
 
@@ -100,6 +104,7 @@ class _TimelineEventViewMessageState extends State<TimelineEventViewMessage>
           ? TimelineEventViewReply(
               timeline: widget.timeline,
               index: index,
+              jumpToEvent: widget.jumpToEvent,
             )
           : null,
       reactions: hasReactions
@@ -140,6 +145,7 @@ class _TimelineEventViewMessageState extends State<TimelineEventViewMessage>
     index = eventIndex;
     var event = widget.timeline.events[eventIndex];
     var sender = widget.timeline.room.getMemberOrFallback(event.senderId);
+    eventId = event.eventId;
 
     senderName = sender.displayName;
     senderAvatar = sender.avatar;

--- a/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
@@ -25,6 +25,7 @@ class TimelineViewEntry extends StatefulWidget {
       this.showDetailed = false,
       this.singleEvent = false,
       this.isThreadTimeline = false,
+      this.highlightedEventId,
       super.key});
   final Timeline timeline;
   final int initialIndex;
@@ -34,6 +35,7 @@ class TimelineViewEntry extends StatefulWidget {
   final Function(String eventId)? jumpToEvent;
   final bool showDetailed;
   final bool isThreadTimeline;
+  final String? highlightedEventId;
 
   // Should be true if we are showing this event on its own, and not as part of a timeline
   final bool singleEvent;
@@ -83,6 +85,7 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
     index = eventIndex;
     time = event.originServerTs;
     showDate = shouldEventShowDate(eventIndex);
+    highlighted = event.eventId == widget.highlightedEventId;
   }
 
   bool shouldEventShowDate(int index) {
@@ -215,7 +218,7 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
                     color: Theme.of(context).colorScheme.primary, width: 3)),
             color: Theme.of(context).colorScheme.surfaceContainer),
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(-3, 0, 0, 0),
+          padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
           child: result,
         ),
       );
@@ -303,11 +306,5 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
         selected = true;
         timelineLayerLink = link;
       });
-  }
-
-  void setHighlighted(bool value) {
-    setState(() {
-      highlighted = value;
-    });
   }
 }

--- a/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
@@ -307,4 +307,11 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
         timelineLayerLink = link;
       });
   }
+
+  void setHighlighted(bool value) {
+    if (mounted)
+      setState(() {
+        highlighted = value;
+      });
+  }
 }

--- a/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
@@ -214,7 +214,10 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
                 left: BorderSide(
                     color: Theme.of(context).colorScheme.primary, width: 3)),
             color: Theme.of(context).colorScheme.surfaceContainer),
-        child: result,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(-3, 0, 0, 0),
+          child: result,
+        ),
       );
     }
 

--- a/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
@@ -21,6 +21,7 @@ class TimelineViewEntry extends StatefulWidget {
       this.onEventHovered,
       this.setEditingEvent,
       this.setReplyingEvent,
+      this.jumpToEvent,
       this.showDetailed = false,
       this.singleEvent = false,
       this.isThreadTimeline = false,
@@ -30,6 +31,7 @@ class TimelineViewEntry extends StatefulWidget {
   final Function(String eventId)? onEventHovered;
   final Function(TimelineEvent? event)? setReplyingEvent;
   final Function(TimelineEvent? event)? setEditingEvent;
+  final Function(String eventId)? jumpToEvent;
   final bool showDetailed;
   final bool isThreadTimeline;
 
@@ -54,6 +56,7 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
 
   bool selected = false;
   bool isThreadReply = false;
+  bool highlighted = false;
   LayerLink? timelineLayerLink;
 
   late DateTime time;
@@ -204,6 +207,17 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
       );
     }
 
+    if (highlighted) {
+      result = Container(
+        decoration: BoxDecoration(
+            border: Border(
+                left: BorderSide(
+                    color: Theme.of(context).colorScheme.primary, width: 3)),
+            color: Theme.of(context).colorScheme.surfaceContainer),
+        child: result,
+      );
+    }
+
     if (timelineLayerLink != null) {
       result = Stack(
         alignment: Alignment.topRight,
@@ -241,6 +255,7 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
               isThreadTimeline: widget.isThreadTimeline,
               detailed: widget.showDetailed || selected,
               overrideShowSender: widget.singleEvent,
+              jumpToEvent: widget.jumpToEvent,
               initialIndex: widget.initialIndex);
       case EventType.roomCreated:
       case EventType.memberJoined:
@@ -271,17 +286,25 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
 
   @override
   void deselect() {
-    setState(() {
-      selected = false;
-      timelineLayerLink = null;
-    });
+    if (mounted)
+      setState(() {
+        selected = false;
+        timelineLayerLink = null;
+      });
   }
 
   @override
   void select(LayerLink link) {
+    if (mounted)
+      setState(() {
+        selected = true;
+        timelineLayerLink = link;
+      });
+  }
+
+  void setHighlighted(bool value) {
     setState(() {
-      selected = true;
-      timelineLayerLink = link;
+      highlighted = value;
     });
   }
 }


### PR DESCRIPTION
~~works by rendering entire timeline offscreen and measuring offset to desired event~~

Came up with a way more elegant solution: by manipulating the display indices of events in the timeline, we can force an arbitrary event to be positioned at the center of the scroll view. Because of this, we can always assume that the event will begin at scroll position `0.0` and so we can simply scroll to `0 + viewHeight/2` to end up with the event positioned in the center of the view

Super happy with this approach!