### PR TITLE
Implement timeline search

### DIFF
--- a/commet/lib/client/components/component_registry.dart
+++ b/commet/lib/client/components/component_registry.dart
@@ -7,6 +7,7 @@ import 'package:commet/client/matrix/components/emoticon/matrix_emoticon_compone
 import 'package:commet/client/matrix/components/emoticon/matrix_emoticon_state_manager.dart';
 import 'package:commet/client/matrix/components/emoticon/matrix_room_emoticon_component.dart';
 import 'package:commet/client/matrix/components/emoticon/matrix_space_emoticon_component.dart';
+import 'package:commet/client/matrix/components/event_search/matrix_event_search_component.dart';
 import 'package:commet/client/matrix/components/gif/matrix_gif_component.dart';
 import 'package:commet/client/matrix/components/invitation/matrix_invitation_component.dart';
 import 'package:commet/client/matrix/components/push_notifications/matrix_push_notification_component.dart';
@@ -30,6 +31,7 @@ class ComponentRegistry {
       MatrixInvitationComponent(client),
       MatrixThreadsComponent(client),
       MatrixDirectMessagesComponent(client),
+      MatrixEventSearchComponent(client)
     ];
   }
 

--- a/commet/lib/client/components/event_search/event_search_component.dart
+++ b/commet/lib/client/components/event_search/event_search_component.dart
@@ -1,0 +1,13 @@
+import 'package:commet/client/client.dart';
+import 'package:commet/client/components/component.dart';
+import 'package:commet/client/timeline_events/timeline_event.dart';
+
+abstract class EventSearchSession {
+  Stream<List<TimelineEvent>> startSearch(String searchTerm);
+
+  bool get currentlySearching;
+}
+
+abstract class EventSearchComponent<T extends Client> implements Component<T> {
+  Future<EventSearchSession> createSearchSession(Room room);
+}

--- a/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
+++ b/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
@@ -6,6 +6,7 @@ import 'package:commet/client/matrix/matrix_timeline.dart';
 import 'package:commet/client/timeline_events/timeline_event.dart';
 import 'package:commet/ui/molecules/timeline_events/timeline_view_entry.dart';
 import 'package:commet/utils/mime.dart';
+// ignore: implementation_imports
 import 'package:matrix/src/event.dart';
 
 class MatrixEventSearchSession extends EventSearchSession {

--- a/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
+++ b/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
@@ -1,0 +1,65 @@
+import 'package:commet/client/client.dart';
+import 'package:commet/client/components/event_search/event_search_component.dart';
+import 'package:commet/client/matrix/matrix_client.dart';
+import 'package:commet/client/matrix/matrix_room.dart';
+import 'package:commet/client/matrix/matrix_timeline.dart';
+import 'package:commet/client/timeline_events/timeline_event.dart';
+import 'package:commet/ui/molecules/timeline_events/timeline_view_entry.dart';
+
+class MatrixEventSearchSession extends EventSearchSession {
+  MatrixTimeline timeline;
+  String? currentSearchTerm;
+  String? prevBatch;
+
+  MatrixEventSearchSession(this.timeline);
+
+  @override
+  bool currentlySearching = false;
+
+  @override
+  Stream<List<TimelineEvent<Client>>> startSearch(String searchTerm) async* {
+    currentSearchTerm = searchTerm;
+    currentlySearching = true;
+    var search = timeline.matrixTimeline!.startSearch(searchTerm: searchTerm);
+    List<TimelineEvent<Client>> result = List.empty();
+    await for (final chunk in search) {
+      result = chunk.$1
+          .map((e) => (timeline.room as MatrixRoom).convertEvent(e))
+          .toList();
+
+      Map<String, TimelineEvent> m = {};
+
+      for (var event in result) {
+        var type = TimelineViewEntryState.eventToDisplayType(event);
+        if (type != TimelineEventWidgetDisplayType.hidden) {
+          m[event.eventId] = event;
+        }
+      }
+
+      if (chunk.$2 != null) {
+        prevBatch = chunk.$2;
+      }
+
+      result = m.values.toList();
+      result.sort((a, b) => b.originServerTs.compareTo(a.originServerTs));
+
+      yield result;
+    }
+
+    currentlySearching = false;
+    yield result;
+  }
+}
+
+class MatrixEventSearchComponent implements EventSearchComponent<MatrixClient> {
+  @override
+  MatrixClient client;
+
+  MatrixEventSearchComponent(this.client);
+
+  @override
+  Future<EventSearchSession> createSearchSession(Room room) async {
+    var timeline = await room.getTimeline();
+    return MatrixEventSearchSession(timeline as MatrixTimeline);
+  }
+}

--- a/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
+++ b/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
@@ -100,8 +100,9 @@ class MatrixEventSearchSession extends EventSearchSession {
   }
 
   bool searchFunc(Event event) {
-    final numMatchingWords =
-        _words!.where((w) => event.plaintextBody.contains(w)).length;
+    final numMatchingWords = _words!
+        .where((w) => event.plaintextBody.toLowerCase().contains(w))
+        .length;
 
     if (_requireAttachment) {
       if (event.hasAttachment == false) {

--- a/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
+++ b/commet/lib/client/matrix/components/event_search/matrix_event_search_component.dart
@@ -23,6 +23,7 @@ class MatrixEventSearchSession extends EventSearchSession {
   bool _requireVideo = false;
   bool _requireAttachment = false;
   String? _requiredType;
+  String? _requiredSender;
 
   static const String hasLinkString = 'has:link';
   static const String hasImageString = 'has:image';
@@ -41,7 +42,12 @@ class MatrixEventSearchSession extends EventSearchSession {
     var typeMatch = _words!.where((w) => w.startsWith("type:")).firstOrNull;
 
     if (typeMatch != null) {
-      _requiredType = typeMatch.split(':').last;
+      _requiredType = typeMatch.split('type:').last;
+    }
+
+    var userMatch = _words!.where((w) => w.startsWith("from:")).firstOrNull;
+    if (userMatch != null) {
+      _requiredSender = userMatch.split('from:').last;
     }
 
     if (_words!.contains(hasLinkString)) _requireUrl = true;
@@ -123,6 +129,12 @@ class MatrixEventSearchSession extends EventSearchSession {
 
     if (_requiredType != null) {
       if (event.type != _requiredType && event.messageType != _requiredType) {
+        return false;
+      }
+    }
+
+    if (_requiredSender != null) {
+      if (event.senderId != _requiredSender) {
         return false;
       }
     }

--- a/commet/lib/client/matrix/components/threads/matrix_thread_timeline.dart
+++ b/commet/lib/client/matrix/components/threads/matrix_thread_timeline.dart
@@ -35,12 +35,31 @@ class MatrixThreadTimeline implements Timeline {
   @override
   StreamController<int> onRemove = StreamController.broadcast();
 
+  final StreamController<void> _loadingStatusChangedController =
+      StreamController.broadcast();
+
+  @override
+  Stream<void> get onLoadingStatusChanged =>
+      _loadingStatusChangedController.stream;
+
   late List<StreamSubscription> subs;
 
   String? nextBatch;
   bool finished = false;
 
   Future? nextChunkRequest;
+
+  @override
+  bool get canLoadFuture => false;
+
+  @override
+  bool get canLoadHistory => nextBatch != null && nextChunkRequest != null;
+
+  @override
+  bool get isLoadingFuture => false;
+
+  @override
+  bool isLoadingHistory = false;
 
   MatrixThreadTimeline({
     required this.client,
@@ -165,6 +184,8 @@ class MatrixThreadTimeline implements Timeline {
       return;
     }
 
+    isLoadingHistory = true;
+
     nextChunkRequest = getThreadEvents(nextBatch: nextBatch);
     var nextEvents = await nextChunkRequest;
 
@@ -174,6 +195,13 @@ class MatrixThreadTimeline implements Timeline {
       events.add(event);
       onEventAdded.add(events.length - 1);
     }
+
+    isLoadingHistory = false;
+  }
+
+  @override
+  Future<void> loadMoreFuture() {
+    throw UnimplementedError();
   }
 
   @override

--- a/commet/lib/client/matrix/matrix_room.dart
+++ b/commet/lib/client/matrix/matrix_room.dart
@@ -410,6 +410,10 @@ class MatrixRoom extends Room {
   TimelineEvent convertEvent(matrix.Event event, {matrix.Timeline? timeline}) {
     var c = client as MatrixClient;
 
+    if (event.redacted) {
+      return MatrixTimelineEventUnknown(event, client: c);
+    }
+
     if (event.type == matrix.EventTypes.Message) {
       if (event.relationshipType == "m.replace")
         return MatrixTimelineEventEdit(event, client: c);
@@ -513,9 +517,9 @@ class MatrixRoom extends Room {
   }
 
   @override
-  Future<Timeline> loadTimeline() async {
+  Future<Timeline> getTimeline({String? contextEventId}) async {
     _timeline = MatrixTimeline(client as MatrixClient, this, matrixRoom);
-    await _timeline!.initTimeline();
+    await _timeline!.initTimeline(contextEventId: contextEventId);
     onTimelineLoaded.add(null);
     return _timeline!;
   }

--- a/commet/lib/client/matrix/matrix_timeline.dart
+++ b/commet/lib/client/matrix/matrix_timeline.dart
@@ -37,14 +37,14 @@ class MatrixTimeline extends Timeline {
     }
   }
 
-  Future<void> initTimeline() async {
+  Future<void> initTimeline({String? contextEventId}) async {
     await (client as MatrixClient).firstSync;
 
     _matrixTimeline = await _matrixRoom.getTimeline(
-      onInsert: onEventInserted,
-      onChange: onEventChanged,
-      onRemove: onEventRemoved,
-    );
+        onInsert: onEventInserted,
+        onChange: onEventChanged,
+        onRemove: onEventRemoved,
+        eventContextId: contextEventId);
 
     // This could maybe make load times realllly slow if we have a ton of stuff in the cache?
     // Might be better to only convert as many as we would need to display immediately and then convert the rest on demand

--- a/commet/lib/client/matrix/matrix_timeline.dart
+++ b/commet/lib/client/matrix/matrix_timeline.dart
@@ -17,6 +17,13 @@ class MatrixTimeline extends Timeline {
 
   late MatrixRoom _room;
 
+  final StreamController<void> _loadingStatusChangedController =
+      StreamController.broadcast();
+
+  @override
+  Stream<void> get onLoadingStatusChanged =>
+      _loadingStatusChangedController.stream;
+
   matrix.Timeline? get matrixTimeline => _matrixTimeline;
 
   MatrixTimeline(
@@ -83,7 +90,32 @@ class MatrixTimeline extends Timeline {
   @override
   Future<void> loadMoreHistory() async {
     if (_matrixTimeline?.canRequestHistory == true) {
-      return await _matrixTimeline!.requestHistory();
+      var f = _matrixTimeline!.requestHistory();
+      _loadingStatusChangedController.add(null);
+
+      await f;
+    }
+  }
+
+  @override
+  bool get canLoadFuture => _matrixTimeline?.canRequestFuture ?? false;
+
+  @override
+  bool get canLoadHistory => _matrixTimeline?.canRequestHistory ?? false;
+
+  @override
+  bool get isLoadingFuture => _matrixTimeline?.isRequestingFuture ?? false;
+
+  @override
+  bool get isLoadingHistory => _matrixTimeline?.isRequestingHistory ?? false;
+
+  @override
+  Future<void> loadMoreFuture() async {
+    if (canLoadFuture) {
+      var f = _matrixTimeline?.requestFuture();
+
+      _loadingStatusChangedController.add(null);
+      await f;
     }
   }
 

--- a/commet/lib/client/room.dart
+++ b/commet/lib/client/room.dart
@@ -109,7 +109,7 @@ abstract class Room {
   Color getColorOfUser(String userId);
 
   /// Gets the timeline of a room, loading it if not yet loaded
-  Future<Timeline> loadTimeline();
+  Future<Timeline> getTimeline({String contextEventId});
 
   /// Enables end to end encryption in a room
   Future<void> enableE2EE();

--- a/commet/lib/client/timeline.dart
+++ b/commet/lib/client/timeline.dart
@@ -72,6 +72,18 @@ abstract class Timeline {
 
   Future<void> loadMoreHistory();
 
+  Future<void> loadMoreFuture();
+
+  bool get isLoadingHistory;
+
+  bool get isLoadingFuture;
+
+  bool get canLoadFuture;
+
+  bool get canLoadHistory;
+
+  Stream<void> get onLoadingStatusChanged;
+
   Future<void> close();
 
   @protected

--- a/commet/lib/debug/log.dart
+++ b/commet/lib/debug/log.dart
@@ -5,7 +5,6 @@ import 'package:commet/main.dart';
 import 'package:commet/utils/notifying_list.dart';
 import 'package:commet/utils/text_utils.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 
 enum LogType { info, debug, error, warning }
 

--- a/commet/lib/main.dart
+++ b/commet/lib/main.dart
@@ -262,6 +262,7 @@ class App extends StatelessWidget {
           return MaterialApp(
             title: 'Commet',
             theme: theme,
+            debugShowCheckedModeBanner: false,
             navigatorKey: navigator,
             localizationsDelegates: T.localizationsDelegates,
             builder: (context, child) => Provider<ClientManager>(

--- a/commet/lib/ui/atoms/role_view.dart
+++ b/commet/lib/ui/atoms/role_view.dart
@@ -10,7 +10,7 @@ class RoleView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var bg = Theme.of(context).colorScheme.surfaceContainerHigh;
+    var bg = Theme.of(context).colorScheme.surfaceContainerLow;
     var fg = Theme.of(context).colorScheme.onSurface;
 
     return Padding(

--- a/commet/lib/ui/atoms/room_header.dart
+++ b/commet/lib/ui/atoms/room_header.dart
@@ -1,12 +1,14 @@
 import 'package:commet/client/components/direct_messages/direct_message_component.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' as m;
 import 'package:flutter/widgets.dart';
 
 import '../../client/client.dart';
 
 class RoomHeader extends StatelessWidget {
-  const RoomHeader(this.room, {super.key, this.onTap});
+  const RoomHeader(this.room, {super.key, this.onTap, this.menu});
   final Room room;
+  final Widget? menu;
   final Function()? onTap;
 
   @override
@@ -23,23 +25,30 @@ class RoomHeader extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(10.0),
           child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              SizedBox(
-                  width: 40,
-                  height: 40,
-                  child: Icon(
-                    isDirectMessage
-                        ? m.Icons.alternate_email_rounded
-                        : m.Icons.tag,
-                  )),
-              Flexible(
-                child: m.Text(
-                  room.displayName,
-                  style: m.Theme.of(context).textTheme.titleMedium,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                      width: 40,
+                      height: 40,
+                      child: Icon(
+                        isDirectMessage
+                            ? m.Icons.alternate_email_rounded
+                            : m.Icons.tag,
+                      )),
+                  Flexible(
+                    child: m.Text(
+                      room.displayName,
+                      style: m.Theme.of(context).textTheme.titleMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
               ),
+              if (menu != null) menu!
             ],
           ),
         ),

--- a/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget.dart
+++ b/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget.dart
@@ -26,8 +26,6 @@ class RoomTimelineWidget extends StatefulWidget {
 
 class _RoomTimelineWidgetState extends State<RoomTimelineWidget>
     with WidgetsBindingObserver {
-  Future? loadingHistory;
-
   GlobalKey timelineViewKey = GlobalKey();
 
   StreamSubscription? sub;
@@ -81,7 +79,6 @@ class _RoomTimelineWidgetState extends State<RoomTimelineWidget>
     Widget result = RoomTimelineWidgetView(
       key: timelineViewKey,
       timeline: widget.timeline,
-      onViewScrolled: onViewScrolled,
       onAttachedToBottom: onAttachedToBottom,
       isThreadTimeline: widget.isThreadTimeline,
       setReplyingEvent: widget.setReplyingEvent,
@@ -96,37 +93,10 @@ class _RoomTimelineWidgetState extends State<RoomTimelineWidget>
     return result;
   }
 
-  void onViewScrolled(
-      {required double offset, required double maxScrollExtent}) {
-    double loadingThreshold = 500;
-    var state = timelineViewKey.currentState as RoomTimelineWidgetViewState?;
-
-    // When the history items are empty, the sliver takes up exactly the height of the viewport, so we should use that height instead
-    if (state?.historyItemsCount == 0) {
-      var renderBox =
-          timelineViewKey.currentContext?.findRenderObject() as RenderBox?;
-      if (renderBox != null) {
-        loadingThreshold = renderBox.size.height;
-      }
-    }
-
-    if (offset > maxScrollExtent - loadingThreshold && loadingHistory == null) {
-      loadMoreHistory();
-    }
-
-    if (state?.attachedToBottom == true) {}
-  }
-
   void onAttachedToBottom() {
     if (widget.timeline.events.isNotEmpty) {
       markAsRead(widget.timeline.events.first);
       widget.clearNotifications?.call(widget.timeline.room);
     }
-  }
-
-  void loadMoreHistory() async {
-    loadingHistory = widget.timeline.loadMoreHistory();
-    await loadingHistory;
-    loadingHistory = null;
   }
 }

--- a/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
+++ b/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
@@ -429,8 +429,14 @@ class RoomTimelineWidgetViewState extends State<RoomTimelineWidgetView> {
       });
       var newTimeline =
           await timeline.room.getTimeline(contextEventId: eventId);
+
       index =
           newTimeline.events.indexWhere((event) => event.eventId == eventId);
+
+      if (index == -1) {
+        return;
+      }
+
       setState(() {
         initFromTimeline(newTimeline);
       });

--- a/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
+++ b/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
@@ -484,8 +484,7 @@ class RoomTimelineWidgetViewState extends State<RoomTimelineWidgetView> {
       highlightedEventState = null;
     }
 
-    int index =
-        -1; // timeline.events.indexWhere((event) => event.eventId == eventId);
+    int index = timeline.events.indexWhere((event) => event.eventId == eventId);
     if (index == -1) {
       setState(() {
         loading = true;

--- a/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_generic.dart
+++ b/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_generic.dart
@@ -1,4 +1,5 @@
-import 'package:commet/client/timeline.dart';
+import 'package:commet/client/client.dart';
+import 'package:commet/client/timeline_events/timeline_event.dart';
 import 'package:commet/client/timeline_events/timeline_event_generic.dart';
 import 'package:commet/ui/molecules/timeline_events/timeline_event_layout.dart';
 import 'package:flutter/material.dart';
@@ -12,9 +13,15 @@ import 'package:tiamat/atoms/avatar.dart';
 
 class TimelineEventViewGeneric extends StatefulWidget {
   const TimelineEventViewGeneric(
-      {required this.timeline, required this.initialIndex, super.key});
-  final Timeline timeline;
+      {this.timeline,
+      this.initialEvent,
+      required this.initialIndex,
+      this.room,
+      super.key});
+  final Timeline? timeline;
   final int initialIndex;
+  final Room? room;
+  final TimelineEvent? initialEvent;
   @override
   State<TimelineEventViewGeneric> createState() =>
       _TimelineEventViewGenericState();
@@ -45,7 +52,13 @@ class _TimelineEventViewGenericState extends State<TimelineEventViewGeneric>
 
   @override
   void initState() {
-    setStateFromindex(widget.initialIndex);
+    if (widget.timeline != null) {
+      setStateFromindex(widget.initialIndex);
+    }
+
+    if (widget.initialEvent != null) {
+      loadStateFromEvent(widget.initialEvent!);
+    }
     super.initState();
   }
 
@@ -103,8 +116,12 @@ class _TimelineEventViewGenericState extends State<TimelineEventViewGeneric>
   }
 
   void setStateFromindex(int index) {
-    var event = widget.timeline.events[index];
+    var event = widget.timeline!.events[index];
+    loadStateFromEvent(event);
+  }
 
+  void loadStateFromEvent(TimelineEvent event) {
+    var room = widget.room ?? widget.timeline?.room;
     if (event is! TimelineEventGeneric) {
       text = event.plainTextBody;
       icon = Icons.question_mark;
@@ -114,7 +131,7 @@ class _TimelineEventViewGenericState extends State<TimelineEventViewGeneric>
     text = event.getBody(timeline: widget.timeline);
     icon = event.icon;
 
-    var sender = widget.timeline.room.getMemberOrFallback(event.senderId);
+    var sender = room!.getMemberOrFallback(event.senderId);
     if (event.showSenderAvatar) {
       senderAvatar = sender.avatar;
     }

--- a/commet/lib/ui/molecules/timeline_events/timeline_event_view_single.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_event_view_single.dart
@@ -1,0 +1,35 @@
+import 'package:commet/client/client.dart';
+import 'package:commet/client/timeline_events/timeline_event.dart';
+import 'package:commet/ui/molecules/timeline_events/events/timeline_event_view_generic.dart';
+import 'package:commet/ui/molecules/timeline_events/events/timeline_event_view_message.dart';
+import 'package:commet/ui/molecules/timeline_events/timeline_view_entry.dart';
+import 'package:flutter/material.dart';
+
+class TimelineEventViewSingle extends StatelessWidget {
+  const TimelineEventViewSingle(
+      {required this.room, required this.event, super.key});
+
+  final TimelineEvent event;
+  final Room room;
+
+  @override
+  Widget build(BuildContext context) {
+    final type = TimelineViewEntryState.eventToDisplayType(event);
+    if (type == TimelineEventWidgetDisplayType.message)
+      return TimelineEventViewMessage(
+        room: room,
+        overrideShowSender: true,
+        initialIndex: 0,
+        detailed: true,
+        initialEvent: event,
+      );
+    if (type == TimelineEventWidgetDisplayType.generic)
+      return TimelineEventViewGeneric(
+        initialIndex: 0,
+        initialEvent: event,
+        room: room,
+      );
+
+    return Container();
+  }
+}

--- a/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_view_entry.dart
@@ -55,7 +55,7 @@ class TimelineViewEntry extends StatefulWidget {
 // It causes extra widget rebuilds, so we check type only during the event update and store it with this enum
 // I thought maybe if we override hashcode of TimelineEventBase it would allow us to just check the type
 // But it didnt. I dont know if there is a way to fix that
-enum _TimelineEventWidgetDisplayType {
+enum TimelineEventWidgetDisplayType {
   message,
   generic,
   hidden,
@@ -76,8 +76,8 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
   bool isThreadReply = false;
   bool highlighted = false;
   bool redacted = false;
-  _TimelineEventWidgetDisplayType _widgetType =
-      _TimelineEventWidgetDisplayType.hidden;
+  TimelineEventWidgetDisplayType _widgetType =
+      TimelineEventWidgetDisplayType.hidden;
   LayerLink? timelineLayerLink;
 
   late DateTime time;
@@ -104,18 +104,23 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
     index = eventIndex;
     time = event.originServerTs;
 
-    if (event is TimelineEventMessage ||
-        event is TimelineEventSticker ||
-        event is TimelineEventEncrypted) {
-      _widgetType = _TimelineEventWidgetDisplayType.message;
-    } else if (event is TimelineEventGeneric) {
-      _widgetType = _TimelineEventWidgetDisplayType.generic;
-    } else {
-      _widgetType = _TimelineEventWidgetDisplayType.hidden;
-    }
+    _widgetType = eventToDisplayType(event);
 
     showDateSeperator = shouldEventShowDate(eventIndex);
     highlighted = event.eventId == widget.highlightedEventId;
+  }
+
+  static TimelineEventWidgetDisplayType eventToDisplayType(
+      TimelineEvent event) {
+    if (event is TimelineEventMessage ||
+        event is TimelineEventSticker ||
+        event is TimelineEventEncrypted) {
+      return TimelineEventWidgetDisplayType.message;
+    } else if (event is TimelineEventGeneric) {
+      return TimelineEventWidgetDisplayType.generic;
+    } else {
+      return TimelineEventWidgetDisplayType.hidden;
+    }
   }
 
   bool shouldEventShowDate(int index) {
@@ -287,7 +292,7 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
       return null;
     }
 
-    if (_widgetType == _TimelineEventWidgetDisplayType.message)
+    if (_widgetType == TimelineEventWidgetDisplayType.message)
       return TimelineEventViewMessage(
           key: eventKey,
           timeline: widget.timeline,
@@ -296,7 +301,7 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
           overrideShowSender: widget.singleEvent,
           jumpToEvent: widget.jumpToEvent,
           initialIndex: widget.initialIndex);
-    if (_widgetType == _TimelineEventWidgetDisplayType.generic)
+    if (_widgetType == TimelineEventWidgetDisplayType.generic)
       return TimelineEventViewGeneric(
         timeline: widget.timeline,
         initialIndex: widget.initialIndex,
@@ -304,7 +309,7 @@ class TimelineViewEntryState extends State<TimelineViewEntry>
       );
 
     if (preferences.developerMode == false &&
-        _widgetType == _TimelineEventWidgetDisplayType.hidden) {
+        _widgetType == TimelineEventWidgetDisplayType.hidden) {
       return null;
     }
 

--- a/commet/lib/ui/organisms/chat/chat.dart
+++ b/commet/lib/ui/organisms/chat/chat.dart
@@ -115,7 +115,7 @@ class ChatState extends State<Chat> {
   }
 
   Future<void> loadTimeline() async {
-    var t = await room.loadTimeline();
+    var t = await room.getTimeline();
     setState(() {
       _timeline = t;
     });
@@ -123,7 +123,7 @@ class ChatState extends State<Chat> {
 
   Future<void> loadThreadTimeline() async {
     Timeline? timeline = room.timeline;
-    timeline ??= await room.loadTimeline();
+    timeline ??= await room.getTimeline();
 
     var threadTimeline = await threadsComponent!.getThreadTimeline(
         roomTimeline: timeline, threadRootEventId: widget.threadId!);

--- a/commet/lib/ui/organisms/room_event_search/room_event_search_widget.dart
+++ b/commet/lib/ui/organisms/room_event_search/room_event_search_widget.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:commet/client/client.dart';
+import 'package:commet/client/components/event_search/event_search_component.dart';
+import 'package:commet/client/timeline_events/timeline_event.dart';
+import 'package:commet/ui/molecules/timeline_events/timeline_event_view_single.dart';
+import 'package:commet/utils/debounce.dart';
+import 'package:flutter/material.dart';
+import 'package:implicitly_animated_list/implicitly_animated_list.dart';
+import 'package:tiamat/tiamat.dart' as tiamat;
+
+class RoomEventSearchWidget extends StatefulWidget {
+  const RoomEventSearchWidget(
+      {required this.room, this.close, this.onEventClicked, super.key});
+  final Room room;
+  final void Function()? close;
+  final void Function(String eventId)? onEventClicked;
+
+  @override
+  State<RoomEventSearchWidget> createState() => _RoomEventSearchWidgetState();
+}
+
+class _RoomEventSearchWidgetState extends State<RoomEventSearchWidget> {
+  TextEditingController controller = TextEditingController();
+  EventSearchSession? searchSession;
+
+  Stream? currentStream;
+  StreamSubscription? currentSubscription;
+  List<TimelineEvent>? currentResults;
+
+  Debouncer debouncer = Debouncer(delay: const Duration(seconds: 1));
+
+  bool loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    currentSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        tiamat.Tile(
+          child: Row(
+            children: [
+              Flexible(
+                child: Padding(
+                  padding: const EdgeInsets.all(1.0),
+                  child: TextField(
+                    autofocus: true,
+                    onChanged: onTextChanged,
+                    style: Theme.of(context).textTheme.bodyMedium!,
+                    controller: controller,
+                    decoration: InputDecoration(
+                        hintText: "Search",
+                        prefix: const SizedBox(
+                          width: 10,
+                        ),
+                        suffix: loading
+                            ? const SizedBox(
+                                width: 15,
+                                height: 15,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ))
+                            : null,
+                        contentPadding: const EdgeInsets.fromLTRB(8, 0, 8, 0)),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
+                child: tiamat.IconButton(
+                  icon: Icons.close,
+                  size: 20,
+                  onPressed: widget.close,
+                ),
+              )
+            ],
+          ),
+        ),
+        if (currentResults != null)
+          Flexible(
+            child: ClipRect(
+              child: ImplicitlyAnimatedList(
+                itemEquality: (a, b) => a.eventId == b.eventId,
+                itemData: currentResults!,
+                itemBuilder: (context, data) {
+                  return Padding(
+                    padding: const EdgeInsets.fromLTRB(4, 2, 4, 2),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Material(
+                          borderRadius: BorderRadius.circular(8),
+                          child: InkWell(
+                            onTap: () =>
+                                widget.onEventClicked?.call(data.eventId),
+                            child: Padding(
+                              padding: const EdgeInsets.all(4.0),
+                              child: TimelineEventViewSingle(
+                                  room: widget.room, event: data),
+                            ),
+                          )),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  void onTextChanged(String value) {
+    debouncer.run(() => startSearch(value));
+    setState(() {
+      loading = debouncer.running;
+    });
+  }
+
+  void startSearch(String value) async {
+    var search = widget.room.client.getComponent<EventSearchComponent>()!;
+
+    searchSession = await search.createSearchSession(widget.room);
+    var stream = searchSession!.startSearch(value);
+    stream.listen(onResultsChanged);
+  }
+
+  void onResultsChanged(List<TimelineEvent<Client>> results) {
+    setState(() {
+      loading = searchSession?.currentlySearching == true;
+      currentResults = results;
+    });
+  }
+}

--- a/commet/lib/ui/organisms/room_event_search/room_event_search_widget.dart
+++ b/commet/lib/ui/organisms/room_event_search/room_event_search_widget.dart
@@ -119,10 +119,25 @@ class _RoomEventSearchWidgetState extends State<RoomEventSearchWidget> {
   }
 
   void onTextChanged(String value) {
-    debouncer.run(() => startSearch(value));
     setState(() {
-      loading = debouncer.running;
+      currentResults = null;
+      currentSubscription?.cancel();
+      searchSession = null;
+      currentStream = null;
+      currentResults = null;
     });
+
+    if (value.trim().isEmpty) {
+      setState(() {
+        debouncer.cancel();
+        loading = false;
+      });
+    } else {
+      debouncer.run(() => startSearch(value));
+      setState(() {
+        loading = debouncer.running;
+      });
+    }
   }
 
   void startSearch(String value) async {
@@ -130,7 +145,7 @@ class _RoomEventSearchWidgetState extends State<RoomEventSearchWidget> {
 
     searchSession = await search.createSearchSession(widget.room);
     var stream = searchSession!.startSearch(value);
-    stream.listen(onResultsChanged);
+    currentSubscription = stream.listen(onResultsChanged);
   }
 
   void onResultsChanged(List<TimelineEvent<Client>> results) {

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu.dart
@@ -1,0 +1,31 @@
+import 'package:commet/client/client.dart';
+import 'package:commet/client/components/event_search/event_search_component.dart';
+import 'package:commet/utils/event_bus.dart';
+import 'package:flutter/material.dart';
+
+class RoomQuickAccessMenu {
+  final Room room;
+  late final List<RoomQuickAccessMenuEntry> actions;
+
+  RoomQuickAccessMenu({required this.room}) {
+    final bool canSearch =
+        room.client.getComponent<EventSearchComponent>() != null;
+
+    actions = [
+      if (canSearch)
+        RoomQuickAccessMenuEntry(
+            name: "Search",
+            action: (context) => EventBus.startSearch.add(null),
+            icon: Icons.search),
+    ];
+  }
+}
+
+class RoomQuickAccessMenuEntry {
+  final String name;
+  final Function(BuildContext context)? action;
+  final IconData icon;
+
+  RoomQuickAccessMenuEntry(
+      {required this.name, required this.action, required this.icon});
+}

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_desktop.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_desktop.dart
@@ -1,0 +1,38 @@
+import 'package:commet/client/client.dart';
+import 'package:commet/ui/organisms/room_quick_access_menu/room_quick_access_menu.dart';
+import 'package:flutter/material.dart';
+import 'package:tiamat/tiamat.dart' as tiamat;
+
+class RoomQuickAccessMenuViewDesktop extends StatefulWidget {
+  const RoomQuickAccessMenuViewDesktop({required this.room, super.key});
+  final Room room;
+  @override
+  State<RoomQuickAccessMenuViewDesktop> createState() =>
+      _RoomQuickAccessMenuViewDesktopState();
+}
+
+class _RoomQuickAccessMenuViewDesktopState
+    extends State<RoomQuickAccessMenuViewDesktop> {
+  late RoomQuickAccessMenu menu;
+
+  @override
+  void initState() {
+    menu = RoomQuickAccessMenu(room: widget.room);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: menu.actions
+          .map((e) => SizedBox(
+              width: 25,
+              height: 25,
+              child: tiamat.IconButton(
+                icon: e.icon,
+                onPressed: () => e.action?.call(context),
+              )))
+          .toList(),
+    );
+  }
+}

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
@@ -29,8 +29,7 @@ class _RoomQuickAccessMenuViewMobileState
       color: Theme.of(context).colorScheme.surfaceContainerLow,
       child: SizedBox(
         height: 50,
-        child: ScaledSafeArea(
-            child: Row(
+        child: Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: menu.actions
               .map((e) => AspectRatio(
@@ -42,7 +41,7 @@ class _RoomQuickAccessMenuViewMobileState
                     )),
                   ))
               .toList(),
-        )),
+        ),
       ),
     );
   }

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
@@ -1,0 +1,49 @@
+import 'package:commet/client/room.dart';
+import 'package:commet/ui/atoms/scaled_safe_area.dart';
+import 'package:commet/ui/organisms/room_quick_access_menu/room_quick_access_menu.dart';
+import 'package:flutter/material.dart';
+import 'package:tiamat/tiamat.dart' as tiamat;
+
+class RoomQuickAccessMenuViewMobile extends StatefulWidget {
+  const RoomQuickAccessMenuViewMobile({required this.room, super.key});
+  final Room room;
+
+  @override
+  State<RoomQuickAccessMenuViewMobile> createState() =>
+      _RoomQuickAccessMenuViewMobileState();
+}
+
+class _RoomQuickAccessMenuViewMobileState
+    extends State<RoomQuickAccessMenuViewMobile> {
+  late RoomQuickAccessMenu menu;
+
+  @override
+  void initState() {
+    menu = RoomQuickAccessMenu(room: widget.room);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Theme.of(context).colorScheme.surfaceContainerLow,
+      child: SizedBox(
+        height: 50,
+        child: ScaledSafeArea(
+            child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: menu.actions
+              .map((e) => AspectRatio(
+                    aspectRatio: 1,
+                    child: SizedBox(
+                        child: tiamat.IconButton(
+                      icon: e.icon,
+                      onPressed: () => e.action?.call(context),
+                    )),
+                  ))
+              .toList(),
+        )),
+      ),
+    );
+  }
+}

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
@@ -1,5 +1,4 @@
 import 'package:commet/client/room.dart';
-import 'package:commet/ui/atoms/scaled_safe_area.dart';
 import 'package:commet/ui/organisms/room_quick_access_menu/room_quick_access_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:tiamat/tiamat.dart' as tiamat;

--- a/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
+++ b/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:commet/config/layout_config.dart';
+import 'package:commet/ui/atoms/scaled_safe_area.dart';
+import 'package:commet/ui/organisms/chat/chat.dart';
+import 'package:commet/ui/organisms/room_event_search/room_event_search_widget.dart';
+import 'package:commet/ui/organisms/room_members_list/room_members_list.dart';
+import 'package:commet/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart';
+import 'package:commet/ui/pages/main/main_page.dart';
+import 'package:commet/utils/event_bus.dart';
+import 'package:flutter/material.dart';
+import 'package:tiamat/atoms/tile.dart';
+import 'package:tiamat/tiamat.dart' as tiamat;
+
+enum _SidePanelState {
+  defaultView,
+  thread,
+  search,
+}
+
+class RoomSidePanel extends StatefulWidget {
+  const RoomSidePanel({required this.state, super.key});
+
+  final MainPageState state;
+
+  @override
+  State<RoomSidePanel> createState() => _RoomSidePanelState();
+}
+
+class _RoomSidePanelState extends State<RoomSidePanel> {
+  String? _currentThreadId;
+  String? get currentThreadId => _currentThreadId;
+
+  _SidePanelState state = _SidePanelState.defaultView;
+
+  late List<StreamSubscription> subs;
+
+  @override
+  void initState() {
+    subs = [
+      EventBus.openThread.stream.listen(onOpenThreadSignal),
+      EventBus.closeThread.stream.listen(onCloseThreadSignal),
+      EventBus.startSearch.stream.listen(onStartSearch),
+    ];
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    for (var sub in subs) {
+      sub.cancel();
+    }
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    bool showBackButton = state == _SidePanelState.thread;
+
+    Widget result = Stack(
+      alignment: Alignment.topRight,
+      children: [
+        tiamat.Tile(child: buildPanelContent(context)),
+        if (showBackButton)
+          ScaledSafeArea(
+            child: Align(
+              alignment: Alignment.topRight,
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: tiamat.CircleButton(
+                    icon: Icons.close,
+                    radius: 24,
+                    onPressed: () => setState(() {
+                          state = _SidePanelState.defaultView;
+                        })),
+              ),
+            ),
+          ),
+      ],
+    );
+
+    if (state == _SidePanelState.thread) {
+      result = Flexible(child: result);
+    }
+
+    return Material(
+      child: result,
+    );
+  }
+
+  Widget buildPanelContent(BuildContext context) {
+    switch (state) {
+      case _SidePanelState.defaultView:
+        return buildDefaultView();
+      case _SidePanelState.thread:
+        return buildThread();
+      case _SidePanelState.search:
+        return buildSearch();
+    }
+  }
+
+  void onOpenThreadSignal((String, String, String) event) {
+    var clientId = event.$1;
+    var roomId = event.$2;
+    var threadId = event.$3;
+
+    EventBus.openRoom.add((roomId, clientId));
+
+    setState(() {
+      _currentThreadId = threadId;
+      state = _SidePanelState.thread;
+    });
+  }
+
+  void onCloseThreadSignal(void event) {
+    setState(() {
+      _currentThreadId = null;
+      state = _SidePanelState.defaultView;
+    });
+  }
+
+  Widget buildDefaultView() {
+    return Column(
+      children: [
+        if (Layout.mobile)
+          RoomQuickAccessMenuViewMobile(
+            room: widget.state.currentRoom!,
+          ),
+        Flexible(
+          child: Container(
+            color: Theme.of(context).colorScheme.surfaceContainer,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+              child: SizedBox(
+                  width: Layout.desktop ? 200 : null,
+                  child: RoomMembersListWidget(widget.state.currentRoom!)),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget buildThread() {
+    return Flexible(
+      child: Tile(
+        caulkPadLeft: true,
+        caulkClipTopLeft: true,
+        caulkClipBottomLeft: true,
+        caulkPadBottom: true,
+        child: Stack(
+          children: [
+            Chat(
+              widget.state.currentRoom!,
+              threadId: currentThreadId,
+              key: ValueKey(
+                  "room-timeline-key-${widget.state.currentRoom!.localId}_thread_$currentThreadId"),
+            ),
+            ScaledSafeArea(
+              child: Align(
+                alignment: Alignment.topRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: tiamat.CircleButton(
+                    icon: Icons.close,
+                    radius: 24,
+                    onPressed: () => EventBus.closeThread.add(null),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget buildSearch() {
+    return SizedBox(
+        width: Layout.desktop ? 300 : null,
+        child: tiamat.Tile.surfaceContainer(
+            child: RoomEventSearchWidget(
+          room: widget.state.currentRoom!,
+          onEventClicked: (eventId) => EventBus.jumpToEvent.add(eventId),
+          close: () => setState(() {
+            state = _SidePanelState.defaultView;
+          }),
+        )));
+  }
+
+  void onStartSearch(void event) {
+    setState(() {
+      state = _SidePanelState.search;
+    });
+  }
+}

--- a/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
+++ b/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
@@ -63,18 +63,16 @@ class _RoomSidePanelState extends State<RoomSidePanel> {
       children: [
         tiamat.Tile(child: buildPanelContent(context)),
         if (showBackButton)
-          ScaledSafeArea(
-            child: Align(
-              alignment: Alignment.topRight,
-              child: Padding(
-                padding: const EdgeInsets.all(24.0),
-                child: tiamat.CircleButton(
-                    icon: Icons.close,
-                    radius: 24,
-                    onPressed: () => setState(() {
-                          state = _SidePanelState.defaultView;
-                        })),
-              ),
+          Align(
+            alignment: Alignment.topRight,
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: tiamat.CircleButton(
+                  icon: Icons.close,
+                  radius: 24,
+                  onPressed: () => setState(() {
+                        state = _SidePanelState.defaultView;
+                      })),
             ),
           ),
       ],

--- a/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
+++ b/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
@@ -182,7 +182,10 @@ class _RoomSidePanelState extends State<RoomSidePanel> {
         child: tiamat.Tile.surfaceContainer(
             child: RoomEventSearchWidget(
           room: widget.state.currentRoom!,
-          onEventClicked: (eventId) => EventBus.jumpToEvent.add(eventId),
+          onEventClicked: (eventId) {
+            EventBus.jumpToEvent.add(eventId);
+            EventBus.focusTimeline.add(null);
+          },
           close: () => setState(() {
             state = _SidePanelState.defaultView;
           }),

--- a/commet/lib/ui/pages/main/main_page.dart
+++ b/commet/lib/ui/pages/main/main_page.dart
@@ -34,7 +34,7 @@ class MainPageState extends State<MainPage> {
   Room? _currentRoom;
   Room? _previousRoom;
   Space? _previousSpace;
-  String? _currentThreadId;
+
   MainPageSubView _currentView = MainPageSubView.home;
 
   StreamSubscription? onSpaceUpdateSubscription;
@@ -47,7 +47,6 @@ class MainPageState extends State<MainPage> {
   Profile get currentUser => getCurrentUser();
   Space? get currentSpace => _currentSpace;
   Room? get currentRoom => _currentRoom;
-  String? get currentThreadId => _currentThreadId;
 
   @override
   void initState() {
@@ -76,8 +75,7 @@ class MainPageState extends State<MainPage> {
     // });
 
     EventBus.openRoom.stream.listen(onOpenRoomSignal);
-    EventBus.openThread.stream.listen(onOpenThreadSignal);
-    EventBus.closeThread.stream.listen(onCloseThreadSignal);
+
     SchedulerBinding.instance.scheduleFrameCallback(onFirstFrame);
   }
 
@@ -138,7 +136,6 @@ class MainPageState extends State<MainPage> {
     setState(() {
       _previousRoom = currentRoom;
       _currentRoom = room;
-      _currentThreadId = null;
     });
 
     EventBus.onSelectedRoomChanged.add(room);
@@ -212,33 +209,5 @@ class MainPageState extends State<MainPage> {
             room: currentRoom!,
           ));
     }
-  }
-
-  void onOpenThreadSignal((String, String, String) event) {
-    var clientId = event.$1;
-    var roomId = event.$2;
-    var threadEventRootId = event.$3;
-
-    var client = clientManager.getClient(clientId);
-    if (client == null) {
-      return;
-    }
-
-    var room = client.getRoom(roomId);
-    if (room == null) {
-      return;
-    }
-
-    selectRoom(room);
-
-    setState(() {
-      _currentThreadId = threadEventRootId;
-    });
-  }
-
-  void onCloseThreadSignal(void event) {
-    setState(() {
-      _currentThreadId = null;
-    });
   }
 }

--- a/commet/lib/ui/pages/main/main_page_view_desktop.dart
+++ b/commet/lib/ui/pages/main/main_page_view_desktop.dart
@@ -7,7 +7,8 @@ import 'package:commet/ui/molecules/space_viewer.dart';
 import 'package:commet/ui/organisms/background_task_view/background_task_view_container.dart';
 import 'package:commet/ui/organisms/home_screen/home_screen.dart';
 import 'package:commet/ui/organisms/chat/chat.dart';
-import 'package:commet/ui/organisms/room_members_list/room_members_list.dart';
+import 'package:commet/ui/organisms/room_quick_access_menu/room_quick_access_menu_desktop.dart';
+import 'package:commet/ui/organisms/room_side_panel/room_side_panel.dart';
 import 'package:commet/ui/organisms/side_navigation_bar/side_navigation_bar.dart';
 import 'package:commet/ui/organisms/space_summary/space_summary.dart';
 import 'package:commet/ui/pages/main/main_page.dart';
@@ -203,6 +204,9 @@ class MainPageViewDesktop extends StatelessWidget {
                 onTap: state.currentRoom?.permissions.canEditAnything == true
                     ? () => state.navigateRoomSettings()
                     : null,
+                menu: RoomQuickAccessMenuViewDesktop(
+                  room: state.currentRoom!,
+                ),
               ),
             ),
           ),
@@ -227,48 +231,11 @@ class MainPageViewDesktop extends StatelessWidget {
                     ),
                   ),
                 ),
-                if (state.currentThreadId != null)
-                  Flexible(
-                    child: Tile(
-                      caulkPadLeft: true,
-                      caulkClipTopLeft: true,
-                      caulkClipBottomLeft: true,
-                      caulkPadBottom: true,
-                      child: Stack(
-                        children: [
-                          Chat(
-                            state.currentRoom!,
-                            threadId: state.currentThreadId,
-                            key: ValueKey(
-                                "room-timeline-key-${state.currentRoom!.localId}_thread_${state.currentThreadId!}"),
-                          ),
-                          Align(
-                            alignment: Alignment.topRight,
-                            child: Padding(
-                              padding: const EdgeInsets.all(8.0),
-                              child: tiamat.CircleButton(
-                                icon: Icons.close,
-                                onPressed: () => EventBus.closeThread.add(null),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                if (state.currentThreadId == null)
-                  Tile.surfaceContainer(
-                    caulkPadLeft: true,
-                    caulkClipTopLeft: true,
-                    caulkClipBottomLeft: true,
-                    caulkPadBottom: true,
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
-                      child: SizedBox(
-                          width: 200,
-                          child: RoomMembersListWidget(state.currentRoom!)),
-                    ),
-                  )
+                RoomSidePanel(
+                  key: ValueKey(
+                      "room-sidepanel-key-${state.currentRoom!.localId}"),
+                  state: state,
+                )
               ],
             ),
           ),

--- a/commet/lib/ui/pages/main/main_page_view_mobile.dart
+++ b/commet/lib/ui/pages/main/main_page_view_mobile.dart
@@ -110,7 +110,7 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
 
   Widget? rightPanel(BuildContext context) {
     if (widget.state.currentRoom != null) {
-      return Tile.surfaceContainer(
+      return Tile(
           child: ScaledSafeArea(
               bottom: false, child: RoomSidePanel(state: widget.state)));
     }

--- a/commet/lib/ui/pages/main/main_page_view_mobile.dart
+++ b/commet/lib/ui/pages/main/main_page_view_mobile.dart
@@ -11,6 +11,7 @@ import 'package:commet/ui/organisms/background_task_view/background_task_view_co
 import 'package:commet/ui/organisms/chat/chat.dart';
 import 'package:commet/ui/organisms/home_screen/home_screen.dart';
 import 'package:commet/ui/organisms/room_members_list/room_members_list.dart';
+import 'package:commet/ui/organisms/room_side_panel/room_side_panel.dart';
 import 'package:commet/ui/organisms/side_navigation_bar/side_navigation_bar.dart';
 import 'package:commet/ui/organisms/space_summary/space_summary.dart';
 import 'package:commet/ui/pages/main/main_page.dart';
@@ -104,39 +105,8 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
   }
 
   Widget? rightPanel(BuildContext context) {
-    if (widget.state.currentThreadId != null &&
-        widget.state.currentRoom != null) {
-      return Tile(
-        child: keyboardAdaptor(
-          Stack(
-            children: [
-              Chat(
-                widget.state.currentRoom!,
-                threadId: widget.state.currentThreadId,
-                key: ValueKey(
-                    "room-timeline-key-${widget.state.currentRoom!.localId}_thread_${widget.state.currentThreadId!}"),
-              ),
-              ScaledSafeArea(
-                child: Align(
-                  alignment: Alignment.topRight,
-                  child: Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: tiamat.CircleButton(
-                      icon: Icons.close,
-                      radius: 24,
-                      onPressed: () => EventBus.closeThread.add(null),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
     if (widget.state.currentRoom != null) {
-      return userList();
+      return RoomSidePanel(state: widget.state);
     }
 
     return null;

--- a/commet/lib/ui/pages/main/main_page_view_mobile.dart
+++ b/commet/lib/ui/pages/main/main_page_view_mobile.dart
@@ -54,6 +54,10 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
       panelsKey.currentState?.reveal(RevealSide.main);
     });
 
+    EventBus.focusTimeline.stream.listen((event) {
+      panelsKey.currentState?.reveal(RevealSide.main);
+    });
+
     super.initState();
   }
 

--- a/commet/lib/ui/pages/main/main_page_view_mobile.dart
+++ b/commet/lib/ui/pages/main/main_page_view_mobile.dart
@@ -110,7 +110,9 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
 
   Widget? rightPanel(BuildContext context) {
     if (widget.state.currentRoom != null) {
-      return RoomSidePanel(state: widget.state);
+      return Tile.surfaceContainer(
+          child: ScaledSafeArea(
+              bottom: false, child: RoomSidePanel(state: widget.state)));
     }
 
     return null;

--- a/commet/lib/utils/debounce.dart
+++ b/commet/lib/utils/debounce.dart
@@ -4,6 +4,8 @@ class Debouncer {
   final Duration delay;
   Timer? _timer;
 
+  bool get running => _timer != null;
+
   Debouncer({required this.delay});
 
   run(void Function() action) {
@@ -13,5 +15,6 @@ class Debouncer {
 
   cancel() {
     _timer?.cancel();
+    _timer = null;
   }
 }

--- a/commet/lib/utils/event_bus.dart
+++ b/commet/lib/utils/event_bus.dart
@@ -29,4 +29,6 @@ class EventBus {
   static StreamController<void> startSearch = StreamController.broadcast();
 
   static StreamController<String> jumpToEvent = StreamController.broadcast();
+
+  static StreamController<void> focusTimeline = StreamController.broadcast();
 }

--- a/commet/lib/utils/event_bus.dart
+++ b/commet/lib/utils/event_bus.dart
@@ -25,4 +25,8 @@ class EventBus {
 
   static StreamController<Room?> onSelectedRoomChanged =
       StreamController<Room?>.broadcast();
+
+  static StreamController<void> startSearch = StreamController.broadcast();
+
+  static StreamController<String> jumpToEvent = StreamController.broadcast();
 }


### PR DESCRIPTION
Closes #263 

Also adds support for jumping to timeline events outside of the currently loaded timeline, related to #243 

Todo:
- [x] Make timeline load events when scrolling to the bottom of a historical view
- [x] Mobile view should automatically slide back to the main panel when clicking on a search item
- [x] Implement advanced search features such as `has:link` or `from:user`