### PR TITLE
Fix invitation button UI and recommendation filtering logic

### DIFF
--- a/commet/lib/ui/organisms/invitation_view/send_invitation.dart
+++ b/commet/lib/ui/organisms/invitation_view/send_invitation.dart
@@ -40,7 +40,7 @@ class _SendInvitationWidgetState extends State<SendInvitationWidget> {
   Widget build(BuildContext context) {
     var dmComponent =
         widget.room.client.getComponent<DirectMessagesComponent>();
-    var recommended = dmComponent?.directMessageRooms ?? [];
+    var recommended = List.from(dmComponent?.directMessageRooms ?? []);
 
     recommended.removeWhere(
       (element) => widget.room.memberIds

--- a/commet/lib/ui/organisms/room_members_list/room_members_list.dart
+++ b/commet/lib/ui/organisms/room_members_list/room_members_list.dart
@@ -1,10 +1,6 @@
 import 'package:commet/client/components/direct_messages/direct_message_component.dart';
-import 'package:commet/client/components/invitation/invitation_component.dart';
 import 'package:commet/client/room.dart';
-import 'package:commet/config/layout_config.dart';
 import 'package:commet/ui/molecules/user_list.dart';
-import 'package:commet/ui/navigation/adaptive_dialog.dart';
-import 'package:commet/ui/organisms/invitation_view/send_invitation.dart';
 import 'package:flutter/material.dart';
 import 'package:tiamat/tiamat.dart' as tiamat;
 
@@ -29,31 +25,10 @@ class _RoomMembersListWidgetState extends State<RoomMembersListWidget> {
 
   @override
   Widget build(BuildContext context) {
-    var iconSize = Layout.mobile ? 40.0 : 35.0;
-    var invitation = widget.room.client.getComponent<InvitationComponent>();
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            const tiamat.Text.labelLow("Room Members"),
-            if (invitation != null &&
-                !isDirectMessage &&
-                widget.room.permissions.canInviteUser)
-              SizedBox(
-                width: iconSize,
-                height: iconSize,
-                child: tiamat.IconButton(
-                  icon: Icons.person_add,
-                  size: iconSize / 2,
-                  onPressed: () => AdaptiveDialog.show(context,
-                      builder: (context) =>
-                          SendInvitationWidget(widget.room, invitation),
-                      title: "Invite"),
-                ),
-              ),
-          ],
-        ),
+        const tiamat.Text.labelLow("Room Members"),
         Expanded(
           child: RoomMemberList(
               key: ValueKey("room-participant-list-key-${widget.room.localId}"),

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu.dart
@@ -1,5 +1,8 @@
 import 'package:commet/client/client.dart';
 import 'package:commet/client/components/event_search/event_search_component.dart';
+import 'package:commet/client/components/invitation/invitation_component.dart';
+import 'package:commet/ui/navigation/adaptive_dialog.dart';
+import 'package:commet/ui/organisms/invitation_view/send_invitation.dart';
 import 'package:commet/utils/event_bus.dart';
 import 'package:flutter/material.dart';
 
@@ -11,7 +14,16 @@ class RoomQuickAccessMenu {
     final bool canSearch =
         room.client.getComponent<EventSearchComponent>() != null;
 
+    final invitation = room.client.getComponent<InvitationComponent>();
+
     actions = [
+      if (invitation != null)
+        RoomQuickAccessMenuEntry(
+            name: "Invite",
+            action: (context) => AdaptiveDialog.show(context,
+                builder: (context) => SendInvitationWidget(room, invitation),
+                title: "Invite"),
+            icon: Icons.person_add),
       if (canSearch)
         RoomQuickAccessMenuEntry(
             name: "Search",

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_desktop.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_desktop.dart
@@ -3,26 +3,14 @@ import 'package:commet/ui/organisms/room_quick_access_menu/room_quick_access_men
 import 'package:flutter/material.dart';
 import 'package:tiamat/tiamat.dart' as tiamat;
 
-class RoomQuickAccessMenuViewDesktop extends StatefulWidget {
+class RoomQuickAccessMenuViewDesktop extends StatelessWidget {
   const RoomQuickAccessMenuViewDesktop({required this.room, super.key});
   final Room room;
-  @override
-  State<RoomQuickAccessMenuViewDesktop> createState() =>
-      _RoomQuickAccessMenuViewDesktopState();
-}
-
-class _RoomQuickAccessMenuViewDesktopState
-    extends State<RoomQuickAccessMenuViewDesktop> {
-  late RoomQuickAccessMenu menu;
-
-  @override
-  void initState() {
-    menu = RoomQuickAccessMenu(room: widget.room);
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
+    final menu = RoomQuickAccessMenu(room: room);
+
     return Row(
       children: menu.actions
           .map((e) => SizedBox(

--- a/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
+++ b/commet/lib/ui/organisms/room_quick_access_menu/room_quick_access_menu_mobile.dart
@@ -3,27 +3,14 @@ import 'package:commet/ui/organisms/room_quick_access_menu/room_quick_access_men
 import 'package:flutter/material.dart';
 import 'package:tiamat/tiamat.dart' as tiamat;
 
-class RoomQuickAccessMenuViewMobile extends StatefulWidget {
+class RoomQuickAccessMenuViewMobile extends StatelessWidget {
   const RoomQuickAccessMenuViewMobile({required this.room, super.key});
   final Room room;
 
   @override
-  State<RoomQuickAccessMenuViewMobile> createState() =>
-      _RoomQuickAccessMenuViewMobileState();
-}
-
-class _RoomQuickAccessMenuViewMobileState
-    extends State<RoomQuickAccessMenuViewMobile> {
-  late RoomQuickAccessMenu menu;
-
-  @override
-  void initState() {
-    menu = RoomQuickAccessMenu(room: widget.room);
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final menu = RoomQuickAccessMenu(room: room);
+
     return Container(
       color: Theme.of(context).colorScheme.surfaceContainerLow,
       child: SizedBox(
@@ -36,6 +23,7 @@ class _RoomQuickAccessMenuViewMobileState
                     child: SizedBox(
                         child: tiamat.IconButton(
                       icon: e.icon,
+                      size: 20,
                       onPressed: () => e.action?.call(context),
                     )),
                   ))

--- a/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
+++ b/commet/lib/ui/organisms/room_side_panel/room_side_panel.dart
@@ -125,6 +125,8 @@ class _RoomSidePanelState extends State<RoomSidePanel> {
         if (Layout.mobile)
           RoomQuickAccessMenuViewMobile(
             room: widget.state.currentRoom!,
+            key: ValueKey(
+                "quick_access_menu_${widget.state.currentRoom!.localId}"),
           ),
         Flexible(
           child: Padding(

--- a/commet/lib/ui/pages/main/main_page_view_desktop.dart
+++ b/commet/lib/ui/pages/main/main_page_view_desktop.dart
@@ -189,6 +189,7 @@ class MainPageViewDesktop extends StatelessWidget {
 
   Widget roomChatView() {
     return Expanded(
+      key: ValueKey("room-chat-view-${state.currentRoom!.localId}"),
       child: Column(
         children: [
           Tile.low(

--- a/commet/lib/ui/pages/main/main_page_view_mobile.dart
+++ b/commet/lib/ui/pages/main/main_page_view_mobile.dart
@@ -115,7 +115,11 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
           caulkClipTopLeft: true,
           caulkClipBottomLeft: true,
           child: ScaledSafeArea(
-              bottom: false, child: RoomSidePanel(state: widget.state)));
+              bottom: false,
+              child: RoomSidePanel(
+                  key: ValueKey(
+                      "room-side-panel-${widget.state.currentRoom!.localId}"),
+                  state: widget.state)));
     }
 
     return null;


### PR DESCRIPTION
Moves the invitation button from the member list to the room quick access menu. Also fixes a bug where the invitation widget would, when filtering users to recommend, would remove rooms from the direct message component's internal list.