### PR TITLE
Add features to the base message-input keyboard

### DIFF
--- a/commet/lib/ui/molecules/message_input.dart
+++ b/commet/lib/ui/molecules/message_input.dart
@@ -584,6 +584,8 @@ class MessageInputState extends State<MessageInput> {
             style: Theme.of(context).textTheme.bodyMedium!,
             maxLines: null,
             contextMenuBuilder: contextMenuBuilder,
+            keyboardType: TextInputType.text,
+            textCapitalization: TextCapitalization.sentences,
             decoration: InputDecoration(
                 contentPadding:
                     EdgeInsets.fromLTRB(8, padding / 2, 4, padding / 2),


### PR DESCRIPTION
This adds the "keyboardType: TextInputType.text" and "textCapitalization: TextCapitalization.sentences" options to the TextInput widget for MessageInput. On iOS, this means that the keyboard has a "done" button (that can be used to dismiss it), and that the first word in every sentence will be, by default, capitalized. It should work the same way on Android. I can't easily test this on Android, but I don't think it should ruin anything, and it should have little to no effect on any platform with a hardware keyboard.