### PR TITLE
Add the ability to dismiss the keyboard by tapping outside of the text area

### DIFF
--- a/commet/lib/ui/atoms/dismiss_keyboard.dart
+++ b/commet/lib/ui/atoms/dismiss_keyboard.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class DismissKeyboard extends StatelessWidget {
+  final Widget child;
+  const DismissKeyboard({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        FocusScopeNode currentFocus = FocusScope.of(context);
+        if (!currentFocus.hasPrimaryFocus &&
+            currentFocus.focusedChild != null) {
+          FocusManager.instance.primaryFocus?.unfocus();
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/commet/lib/ui/atoms/keyboard_adaptor.dart
+++ b/commet/lib/ui/atoms/keyboard_adaptor.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:commet/ui/atoms/dismiss_keyboard.dart';
 import 'package:commet/ui/atoms/scaled_safe_area.dart';
 import 'package:commet/utils/scaled_app.dart';
 import 'package:flutter/material.dart';
@@ -14,9 +15,10 @@ class KeyboardAdaptor extends StatelessWidget {
     var scaledQuery = MediaQuery.of(context).scale();
     var offset = max(scaledQuery.viewInsets.bottom, scaledQuery.padding.bottom);
 
-    return ScaledSafeArea(
-        bottom: false,
-        child: Padding(
-            padding: EdgeInsets.fromLTRB(0, 0, 0, offset), child: child));
+    return DismissKeyboard(
+        child: ScaledSafeArea(
+            bottom: false,
+            child: Padding(
+                padding: EdgeInsets.fromLTRB(0, 0, 0, offset), child: child)));
   }
 }


### PR DESCRIPTION
This adds a widget, DismissKeyboard, that dismisses the keyboard when the focus is no longer in a text field, and wraps the KeyboardAdaptor widget in that widget. The net result is that, if you tap in the area around the message input (but not in the text field), the keyboard will go away. This provides a way to dismiss the keyboard on iOS, which doesn't have a button to dismiss the keyboard normally by default.

It would also be possible to wrap the entire application in the widget, which would mean tapping *anywhere* outside of the input area would close the keyboard, but I decided to start small here, and I didn't want to mess around with main.dart quite yet.

It should have no effect on any device with a hardware keyboard.