### PR TITLE
remove experimental 'encrypted url preview'

### DIFF
--- a/commet/lib/client/matrix/components/url_preview/matrix_url_preview_component.dart
+++ b/commet/lib/client/matrix/components/url_preview/matrix_url_preview_component.dart
@@ -1,5 +1,4 @@
 import 'package:commet/client/components/url_preview/url_preview_component.dart';
-import 'package:commet/client/matrix/extensions/matrix_client_extensions.dart';
 import 'package:commet/client/matrix/matrix_client.dart';
 import 'package:commet/client/matrix/matrix_mxc_image_provider.dart';
 import 'package:commet/client/matrix/matrix_room.dart';

--- a/commet/lib/config/preferences.dart
+++ b/commet/lib/config/preferences.dart
@@ -32,7 +32,7 @@ class Preferences {
   static const String _pushGateway = "push_gateway";
   static const String _lastDownloadLocation = "last_download_location";
   static const String _stickerCompatibilityMode = "sticker_compatibility_mode";
-  static const String _urlPreviewInE2EEChat = "use_url_preview_in_e2ee_chat";
+  static const String _urlPreviewInE2EEChat = "enable_url_preview_in_e2ee_chat";
   static const String _messageEffectsEnabled = "message_effects_enabled";
   static const String _lastForegroundServiceSucceeded =
       "did_last_foreground_service_run_succeed";

--- a/commet/lib/ui/pages/settings/categories/app/general_settings_page.dart
+++ b/commet/lib/ui/pages/settings/categories/app/general_settings_page.dart
@@ -31,17 +31,17 @@ class GeneralSettingsPageState extends State<GeneralSettingsPage> {
       args: [proxyUrl],
       name: "labelGifSearchDescription");
 
-  String get labelEncryptedPreview => Intl.message(
-      "URL Preview in Encrypted Chats (Experimental)",
+  String get labelUrlPreviewInEncryptedChatTitle => Intl.message(
+      "URL Preview in Encrypted Chats",
       desc:
-          "Label for the toggle for enabling and disabling encrypted url preview",
-      name: "labelEncryptedPreview");
+          "Label for the toggle for enabling and disabling use of url previews in encrypted chats",
+      name: "labelUrlPreviewInEncryptedChatTitle");
 
-  String labelEncryptedPreviewDescription(proxyUrl) => Intl.message(
-      "Enable use of a proxy server ($proxyUrl) to get url preview in an encrypted chat. The content of these requests will be hidden from your homeserver using Commet's 'encrypted url preview'\nLearn more: https://github.com/commetchat/encrypted_url_preview",
-      desc: "Explains briefly how encrypted url preview works",
-      args: [proxyUrl],
-      name: "labelEncryptedPreviewDescription");
+  String get labelUrlPreviewInEncryptedChatDescription => Intl.message(
+      "This will expose any URLs sent in your encrypted chats to your homeserver in order to fetch the preview",
+      desc:
+          "description for the toggle for enabling and disabling use of url previews in encrypted chats",
+      name: "labelUrlPreviewInEncryptedChatDescription");
 
   String get labelMessageEffectsTitle => Intl.message("Message Effects",
       desc:
@@ -87,9 +87,8 @@ class GeneralSettingsPageState extends State<GeneralSettingsPage> {
             ),
             settingToggle(
               enableEncryptedPreview,
-              title: labelEncryptedPreview,
-              description:
-                  labelEncryptedPreviewDescription("telescope.commet.chat"),
+              title: labelUrlPreviewInEncryptedChatTitle,
+              description: labelUrlPreviewInEncryptedChatDescription,
               onChanged: (value) async {
                 setState(() {
                   enableEncryptedPreview = value;

--- a/commet/pubspec.lock
+++ b/commet/pubspec.lock
@@ -70,14 +70,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  basic_utils:
-    dependency: transitive
-    description:
-      name: basic_utils
-      sha256: "2064b21d3c41ed7654bc82cc476fd65542e04d60059b74d5eed490a4da08fc6c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.7.0"
   blurhash_dart:
     dependency: transitive
     description:
@@ -375,15 +367,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
-  encrypted_url_preview:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "38ae4d905739237277decea9c564d7b7ebf2d52e"
-      url: "https://github.com/commetchat/encrypted_url_preview.git"
-    source: git
-    version: "1.0.0"
   enhanced_enum:
     dependency: transitive
     description:

--- a/commet/pubspec.yaml
+++ b/commet/pubspec.yaml
@@ -75,8 +75,7 @@ dependencies:
       ref: main
   matrix_dart_sdk_drift_db:
     git: https://github.com/commetchat/matrix-dart-sdk-drift-db.git
-  encrypted_url_preview: 
-    git: https://github.com/commetchat/encrypted_url_preview.git
+
   signal_sticker_api: 
     git: https://github.com/commetchat/signal-sticker-api.git
   starfield: 


### PR DESCRIPTION
For a few reasons, I no longer wish to have this in the app.

While I think the concept has some merit, having to use a hard coded public key for encrypting requests seems to me like a somewhat fundamental flaw, as it creates a single point of failure where if the private key was ever found, any recorded requests could be decrypted. 

This is being replaced with a more typical option to just fetch url previews from the homeserver as usual. 