### PR TITLE
Added some missing libraries for WebRTC

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,8 @@
 
         libraries = with pkgs; [
               olm
+              libdrm
+              mesa
         ];
 
         packages = with pkgs; [


### PR DESCRIPTION
After the sdk bump I was getting these errors when building within the dev shell:

```
/nix/store/vcvhwiilizhijk7ywyn58p9l005n9sbn-binutils-2.43.1/bin/ld: warning: libgbm.so.1, needed by /home/zach/Development/commet/commet/linux/flutter/ephemeral/.plugin_symlinks/flutter_webrtc/linux/../third_party/libwebrtc/lib/linux-x64/libwebrtc.so, not found (try using -rpath or -rpath-link)
/nix/store/vcvhwiilizhijk7ywyn58p9l005n9sbn-binutils-2.43.1/bin/ld: warning: libdrm.so.2, needed by /home/zach/Development/commet/commet/linux/flutter/ephemeral/.plugin_symlinks/flutter_webrtc/linux/../third_party/libwebrtc/lib/linux-x64/libwebrtc.so, not found (try using -rpath or -rpath-link)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

