### PR TITLE
Dont generate space color scheme in parallel

### DIFF
--- a/commet/lib/client/matrix/components/space_color_scheme/matrix_space_color_scheme_component.dart
+++ b/commet/lib/client/matrix/components/space_color_scheme/matrix_space_color_scheme_component.dart
@@ -1,6 +1,7 @@
 import 'package:commet/client/components/space_color_scheme/space_color_scheme_component.dart';
 import 'package:commet/client/matrix/matrix_client.dart';
 import 'package:commet/client/matrix/matrix_space.dart';
+import 'package:commet/utils/task_scheduler.dart';
 import 'package:flutter/src/material/color_scheme.dart';
 
 class MatrixSpaceColorSchemeComponent
@@ -14,22 +15,27 @@ class MatrixSpaceColorSchemeComponent
   @override
   MatrixSpace space;
 
+  static TaskScheduler scheduler = OneAtATimeScheduler();
+
   MatrixSpaceColorSchemeComponent(this.client, this.space) {
     _scheme = ColorScheme.fromSeed(seedColor: space.color);
-    updateColorScheme();
-    space.onUpdate.listen((_) => updateColorScheme());
+
+    MatrixSpaceColorSchemeComponent.scheduler.enqueue(updateColorScheme);
+
+    space.onUpdate.listen((_) {
+      MatrixSpaceColorSchemeComponent.scheduler.enqueue(updateColorScheme);
+    });
   }
 
   late ColorScheme _scheme;
 
-  void updateColorScheme() {
+  Future<void> updateColorScheme() async {
     if (space.avatar != null) {
-      ColorScheme.fromImageProvider(
-              provider: space.avatar!,
-              dynamicSchemeVariant: DynamicSchemeVariant.tonalSpot)
-          .then((result) {
-        _scheme = result;
-      });
+      var scheme = await ColorScheme.fromImageProvider(
+          provider: space.avatar!,
+          dynamicSchemeVariant: DynamicSchemeVariant.tonalSpot);
+
+      _scheme = scheme;
     }
   }
 }

--- a/commet/lib/utils/task_scheduler.dart
+++ b/commet/lib/utils/task_scheduler.dart
@@ -1,0 +1,37 @@
+import 'dart:collection';
+
+import 'package:commet/debug/log.dart';
+
+abstract class TaskScheduler {
+  enqueue(Future<void> Function() callback);
+}
+
+class OneAtATimeScheduler implements TaskScheduler {
+  Queue<Future<void> Function()> remainingTasks = Queue();
+
+  Future<void>? currentFuture;
+
+  enqueue(Future<void> Function() callback) {
+    remainingTasks.add(callback);
+
+    if (currentFuture == null) {
+      currentFuture = runQueue();
+    }
+  }
+
+  Future<void> runQueue() async {
+    while (remainingTasks.isNotEmpty) {
+      await Future.delayed(Duration(milliseconds: 10));
+      var task = remainingTasks.removeFirst();
+      ;
+
+      try {
+        await task();
+      } catch (err, trace) {
+        Log.onError(err, trace);
+      }
+    }
+
+    currentFuture = null;
+  }
+}


### PR DESCRIPTION
I noticed some poor performance at startup, seems to be a result of loading and processing all the space avatar images on startup, so instead of running in parallel, this adjusts it to run sequentially