### PR TITLE
Set build number with script

### DIFF
--- a/commet/pubspec.yaml
+++ b/commet/pubspec.yaml
@@ -1,5 +1,5 @@
 name: commet
-version: 0.0.1+1
+version: 0.4.0+717
 publish_to: none
 description: Your space to connect
 environment: 

--- a/commet/scripts/build_release.dart
+++ b/commet/scripts/build_release.dart
@@ -79,11 +79,13 @@ Future<void> main(List<String> args) async {
       "VERSION_TAG=$version",
       "--dart-define",
       "ENABLE_GOOGLE_SERVICES=$enableGoogleServices",
+      "--dart-define",
+      "BUILD_DATE=${DateTime.now().millisecondsSinceEpoch}",
       if (buildDetail != null) "--dart-define",
       if (buildDetail != null) "BUILD_DETAIL=$buildDetail",
       if (platform == "web") "--dart-define",
       if (platform == "web") "FLUTTER_WEB_CANVASKIT_URL=canvaskit/",
-      if (platform == "web") "--source-maps"
+      if (platform == "web") "--source-maps",
     ],
     runInShell: true,
   );

--- a/commet/scripts/set_build_number.sh
+++ b/commet/scripts/set_build_number.sh
@@ -1,0 +1,2 @@
+export BUILD_NUMBER=`git rev-list --count main`
+perl -i -pe 's/^(version:\s+\d+\.\d+\.\d+\+)(\d+)$/$1.$ENV{BUILD_NUMBER}/e' pubspec.yaml


### PR DESCRIPTION
build number is set based on the number of commits in `main`, it wont always be in sync, but this script should be run and then committed as the last step before a release