### PR TITLE
Add an option to only show one account at a time

### DIFF
--- a/commet/lib/client/client_manager.dart
+++ b/commet/lib/client/client_manager.dart
@@ -30,9 +30,13 @@ class ClientManager {
 
   List<Room> get rooms => _rooms;
 
-  List<Room> get singleRooms {
+  List<Room> singleRooms({Client? filterClient}) {
     var result = List<Room>.empty(growable: true);
     for (var client in clients) {
+      if (filterClient != null && client != filterClient) {
+        continue;
+      }
+
       var dmComp = client.getComponent<DirectMessagesComponent>();
 
       for (var room in client.rooms) {

--- a/commet/lib/config/preferences.dart
+++ b/commet/lib/config/preferences.dart
@@ -57,6 +57,8 @@ class Preferences {
 
   static const String _syncedCalendarUrls = "synced_calendar_urls";
 
+  static const String _filterClientId = "filter_client_id";
+
   static const String _previewUrlsInNotification =
       "preview_urls_in_notification";
 
@@ -566,4 +568,16 @@ class Preferences {
 
     return HotKey.fromJson(jsonDecode(item));
   }
+
+  Future<void> setFilterClient(String? id) async {
+    if (id == null) {
+      await _preferences!.remove(_filterClientId);
+    } else {
+      await _preferences!.setString(_filterClientId, id);
+    }
+
+    _onSettingChanged.add(null);
+  }
+
+  String? get filterClient => _preferences?.getString(_filterClientId);
 }

--- a/commet/lib/ui/pages/main/main_page_view_desktop.dart
+++ b/commet/lib/ui/pages/main/main_page_view_desktop.dart
@@ -189,6 +189,7 @@ class MainPageViewDesktop extends StatelessWidget {
                     ),
                     Flexible(
                       child: DirectMessageList(
+                        filterClient: state.filterClient,
                         directMessages: state.clientManager.directMessages,
                         onSelected: (room) => state.selectRoom(room),
                       ),
@@ -207,7 +208,10 @@ class MainPageViewDesktop extends StatelessWidget {
               caulkClipBottomLeft: true,
               caulkPadTop: true,
               caulkPadBottom: true,
-              child: HomeScreen(clientManager: state.clientManager),
+              child: HomeScreen(
+                clientManager: state.clientManager,
+                filterClient: state.filterClient,
+              ),
             ),
           ),
         if (state.currentRoom != null) roomChatView(),

--- a/commet/lib/ui/pages/main/main_page_view_mobile.dart
+++ b/commet/lib/ui/pages/main/main_page_view_mobile.dart
@@ -148,51 +148,54 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
   }
 
   Widget navigation(BuildContext newContext) {
-    return Row(
-      children: [
-        Tile(
-          caulkPadRight: true,
-          caulkClipTopRight: true,
-          caulkClipBottomRight: true,
-          caulkBorderRight: true,
-          mode: TileType.surfaceDim,
-          child: ScaledSafeArea(
-            bottom: false,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(0, 4, 0, 0),
-              child: SideNavigationBar(
-                currentUser: widget.state.getCurrentUser(),
-                onSpaceSelected: (space) {
-                  widget.state.selectSpace(space);
-                },
-                clearSpaceSelection: () {
-                  widget.state.clearSpaceSelection();
-                },
-                onHomeSelected: () {
-                  widget.state.selectHome();
-                },
-                onDirectMessageSelected: (room) {
-                  widget.state.selectHome();
-                  widget.state.selectRoom(room);
-                  panelsKey.currentState?.reveal(RevealSide.main);
-                },
-                extraEntryBuilders: [
-                  (width) {
-                    return SidebarCallsList(
-                        widget.state.clientManager.callManager, width);
-                  }
-                ],
+    return Material(
+      color: Colors.transparent,
+      child: Row(
+        children: [
+          Tile(
+            caulkPadRight: true,
+            caulkClipTopRight: true,
+            caulkClipBottomRight: true,
+            caulkBorderRight: true,
+            mode: TileType.surfaceDim,
+            child: ScaledSafeArea(
+              bottom: false,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(0, 4, 0, 0),
+                child: SideNavigationBar(
+                  currentUser: widget.state.getCurrentUser(),
+                  onSpaceSelected: (space) {
+                    widget.state.selectSpace(space);
+                  },
+                  clearSpaceSelection: () {
+                    widget.state.clearSpaceSelection();
+                  },
+                  onHomeSelected: () {
+                    widget.state.selectHome();
+                  },
+                  onDirectMessageSelected: (room) {
+                    widget.state.selectHome();
+                    widget.state.selectRoom(room);
+                    panelsKey.currentState?.reveal(RevealSide.main);
+                  },
+                  extraEntryBuilders: [
+                    (width) {
+                      return SidebarCallsList(
+                          widget.state.clientManager.callManager, width);
+                    }
+                  ],
+                ),
               ),
             ),
           ),
-        ),
-        if (widget.state.currentView == MainPageSubView.home)
-          directMessagesView(),
-        if (widget.state.currentView == MainPageSubView.space &&
-            widget.state.currentSpace != null)
-          spaceRoomSelector(newContext),
-        const BackgroundTaskViewContainer()
-      ],
+          if (widget.state.currentView == MainPageSubView.home)
+            directMessagesView(),
+          if (widget.state.currentView == MainPageSubView.space &&
+              widget.state.currentSpace != null)
+            spaceRoomSelector(newContext),
+          const BackgroundTaskViewContainer()
+        ],
+      ),
     );
   }
 
@@ -276,6 +279,7 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
     return Tile(
         child: HomeScreen(
       clientManager: widget.state.clientManager,
+      filterClient: widget.state.filterClient,
       onBurgerMenuTap: () {
         panelsKey.currentState?.reveal(RevealSide.left);
       },
@@ -327,6 +331,7 @@ class _MainPageViewMobileState extends State<MainPageViewMobile> {
                 ),
                 Flexible(
                   child: DirectMessageList(
+                    filterClient: widget.state.filterClient,
                     directMessages: widget.state.clientManager.directMessages,
                     onSelected: (room) {
                       setState(() {

--- a/commet/lib/utils/event_bus.dart
+++ b/commet/lib/utils/event_bus.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:commet/client/client.dart';
 import 'package:commet/client/components/message_effects/message_effect_particles.dart';
 import 'package:commet/client/room.dart';
 import 'package:commet/client/space.dart';
@@ -22,6 +23,9 @@ class EventBus {
       StreamController<(String, String, String)>.broadcast();
 
   static StreamController<void> closeThread = StreamController.broadcast();
+
+  static StreamController<Client?> setFilterClient =
+      StreamController.broadcast();
 
   /// Called when the user initially logs in to the app, or on app startup when atleast one user account is already logged in
   static StreamController<BuildContext> onLoggedIn =


### PR DESCRIPTION
For people who prefer a more traditional account switcher, this will filter out rooms and spaces which do not belong to the current account.

Note, the hidden accounts are still active and syncing. It may be a good idea in the future to disconnect accounts which aren't being actively used, but keeping them running is much simpler for now, and also allows instant swapping without any delay for reconnecting