### PR TITLE
Fix typo in intl_fr.arb

### DIFF
--- a/commet/assets/l10n/intl_fr.arb
+++ b/commet/assets/l10n/intl_fr.arb
@@ -375,7 +375,7 @@
     "type": "text",
     "placeholders": {}
   },
-  "sendEncryptedMessagePrompt": "A envoyé un message chiffré",
+  "sendEncryptedMessagePrompt": "Envoyer un message chiffré",
   "@sendEncryptedMessagePrompt": {
     "description": "Placeholder text for message input in an encrypted room",
     "type": "text",


### PR DESCRIPTION
Small patch for french language.

For non-french speakers : the text "A envoyé un message chiffré" reads like "Has send an encrypted message" in french instead of "Envoyer un message chiffré" which reads like "Send an encrypted message".
