### PR TITLE
Add docker support for web client (#635)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Git
+.git/
+
+# Build outputs
+commet/build/
+**/build/
+
+# IDE
+.vscode/
+.idea/
+*.iml
+
+# Remove platforms not needed for web
+commet/android/
+commet/ios/
+commet/macos/
+commet/linux/
+commet/windows/
+
+# Other files
+commet/assets/js/package/
+commet/integration_test/
+commet/test_driver/
+commet/integration_test/
+commet/coverage/
+*.tar.gz
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ghcr.io/cirruslabs/flutter:3.35.4 AS build
+
+RUN sudo apt-get update && sudo apt-get install -y \
+    ninja-build \
+    libgtk-3-dev \
+    libmpv-dev \
+    mpv \
+    ffmpeg \
+    webkit2gtk-4.1
+
+# Rust nightly for vodozemac
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+
+WORKDIR /app
+COPY . .
+WORKDIR /app/commet
+
+# Codegen and prepare-web
+RUN dart run scripts/codegen.dart
+RUN ./scripts/prepare-web.sh
+
+ARG GIT_HASH=unknown
+ARG VERSION_TAG=v0.0.0
+
+# Build with flutter web
+RUN dart run scripts/build_release.dart --platform web --git_hash $GIT_HASH --version_tag $VERSION_TAG
+
+FROM nginx:alpine
+RUN rm -rf /usr/share/nginx/html
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/commet/build/web /usr/share/nginx/html
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cirruslabs/flutter:3.35.4 AS build
+FROM ghcr.io/cirruslabs/flutter:3.41.1 AS build
 
 RUN sudo apt-get update && sudo apt-get install -y \
     ninja-build \

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Hi, I added some initial docker support because I saw the issue #635 for it and I was also interested in deploying it in my server.

The docker is multistage much like in [Fluffychat's](https://github.com/krille-chan/fluffychat/blob/main/Dockerfile) case although I decided to stick to the flutter version that was being used for commet instead of latest for stability.

I also added
```Dockerfile
ARG GIT_HASH=unknown
ARG VERSION_TAG=v0.0.0
```
To set a specific version and commit with the command:

```sh
docker build --build-arg GIT_HASH=$(git rev-parse --short HEAD) --build-arg VERSION_TAG=<version> -t <container_name> .
```

I have tested the client in localhost and was able to build, deploy and login with my account to my homeserver in https://prisma.moe.

I haven't developed in flutter so the dockerignore might lack some exclusions.

lmk if you feel it needs any changes!