### PR TITLE
Fix error propagation in LiveKit backend

### DIFF
--- a/commet/lib/client/matrix/components/voip_room/matrix_livekit_backend.dart
+++ b/commet/lib/client/matrix/components/voip_room/matrix_livekit_backend.dart
@@ -103,8 +103,7 @@ class MatrixLivekitBackend {
     final fociUrl = await getFociUrl();
 
     if (fociUrl.isEmpty) {
-      Log.e("Failed to find a valid LiveKit service");
-      return null;
+      throw Exception("Failed to find a valid LiveKit service");
     }
 
     final selectedFocus = fociUrl.first;
@@ -114,8 +113,7 @@ class MatrixLivekitBackend {
         .requestOpenIdToken(room.matrixRoom.client.userID!, {});
 
     if (selectedFocus.scheme != "https") {
-      Log.e("Selected focus jwt does not use https");
-      return null;
+      throw Exception("Selected focus JWT does not use HTTPS");
     }
 
     Log.d("Received token from homeserver: ${token}");
@@ -133,8 +131,7 @@ class MatrixLivekitBackend {
 
     var result = await http.post(uri, body: jsonEncode(body));
     if (result.statusCode != 200) {
-      Log.e("Failed to get sfu!");
-      return null;
+      throw Exception("Failed to get sfu! HTTP Error ${result.statusCode}");
     }
 
     var data = jsonDecode(result.body) as Map<String, dynamic>;

--- a/commet/lib/client/matrix/components/voip_room/matrix_voip_room_component.dart
+++ b/commet/lib/client/matrix/components/voip_room/matrix_voip_room_component.dart
@@ -78,7 +78,7 @@ class MatrixVoipRoomComponent
   @override
   Future<VoipSession?> joinCall() async {
     currentSession = await backend.join();
-    currentSession!.onStateChanged.listen(onStateChanged);
+    currentSession?.onStateChanged.listen(onStateChanged);
     return currentSession;
   }
 


### PR DESCRIPTION
Fixes an issue mentioned on the Matrix room where when joining a call, a null pointer was causing errors to not propagate as readable dialogs and masking the reason why the LiveKit setup wasn't working (in this case no SFU). I also added an HTTP error code in the case of an SFU failure, as that can help diagnose where specifically it's failing.