### PR TITLE
Fix 5 bugs: preference crash, async setState, firstFrame, event conversion, onKey

### DIFF
--- a/commet/lib/client/matrix/matrix_timeline.dart
+++ b/commet/lib/client/matrix/matrix_timeline.dart
@@ -7,6 +7,7 @@ import 'package:commet/client/matrix/timeline_events/matrix_timeline_event.dart'
 import 'package:commet/client/timeline_events/timeline_event.dart';
 import 'package:commet/client/timeline_events/timeline_event_message.dart';
 import 'package:commet/client/timeline_events/timeline_event_sticker.dart';
+import 'package:commet/debug/log.dart';
 
 import '../client.dart';
 import 'package:matrix/matrix.dart' as matrix;
@@ -64,8 +65,14 @@ class MatrixTimeline extends Timeline {
 
   void convertAllTimelineEvents() {
     for (int i = 0; i < _matrixTimeline!.events.length; i++) {
-      var converted = _room.convertEvent(_matrixTimeline!.events[i]);
-      insertEvent(i, converted);
+      try {
+        var converted = _room.convertEvent(_matrixTimeline!.events[i]);
+        insertEvent(i, converted);
+      } catch (e, s) {
+        Log.onError(e, s,
+            content:
+                "Failed to convert timeline event at index $i: ${_matrixTimeline!.events[i].eventId}");
+      }
     }
   }
 

--- a/commet/lib/ui/molecules/message_input.dart
+++ b/commet/lib/ui/molecules/message_input.dart
@@ -528,6 +528,10 @@ class MessageInputState extends State<MessageInput> {
   KeyEventResult onKey(FocusNode node, KeyEvent event) {
     if (BuildConfig.MOBILE) return KeyEventResult.ignored;
 
+    // Only process KeyDownEvent to avoid duplicate handling from
+    // KeyUpEvent and KeyRepeatEvent on Windows
+    if (event is! KeyDownEvent) return KeyEventResult.ignored;
+
     if (!preferences.disableTextCursorManagement.value) {
       if (HardwareKeyboard.instance
           .isLogicalKeyPressed(LogicalKeyboardKey.backspace)) {

--- a/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
+++ b/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
@@ -225,6 +225,11 @@ class RoomTimelineWidgetViewState extends State<RoomTimelineWidgetView> {
       setState(() {
         firstFrame = false;
       });
+    } else {
+      // If the scroll controller has no clients yet (e.g. no events loaded),
+      // retry on the next frame to avoid firstFrame staying true forever,
+      // which would keep the timeline permanently hidden via Offstage.
+      WidgetsBinding.instance.addPostFrameCallback(onAfterFirstFrame);
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/commet/lib/ui/organisms/chat/chat.dart
+++ b/commet/lib/ui/organisms/chat/chat.dart
@@ -119,6 +119,7 @@ class ChatState extends State<Chat> {
 
   Future<void> loadTimeline() async {
     var t = await room.getTimeline();
+    if (!mounted) return;
     setState(() {
       _timeline = t;
     });
@@ -130,6 +131,7 @@ class ChatState extends State<Chat> {
 
     var threadTimeline = await threadsComponent!.getThreadTimeline(
         roomTimeline: timeline, threadRootEventId: widget.threadId!);
+    if (!mounted) return;
     setState(() {
       _timeline = threadTimeline;
     });

--- a/commet/lib/utils/update_checker.dart
+++ b/commet/lib/utils/update_checker.dart
@@ -24,7 +24,7 @@ class UpdateChecker {
       return;
     }
 
-    if (preferences.checkForUpdates != true) {
+    if (preferences.checkForUpdates.value != true) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Fix Preference comparison crash** in update_checker.dart - `preferences.checkForUpdates != true` throws because `Preference.==` is deliberately overridden to throw. Fixed by using `.value` property. (#736)
- **Add mounted guard** before setState after async in chat.dart - `loadTimeline()` and `loadThreadTimeline()` can complete after the widget is disposed, causing null errors. (#737)
- **Fix timeline permanently hidden** - `firstFrame` stays `true` forever if `ScrollController` has no clients on the first frame (e.g. empty room). Now retries on subsequent frames until the controller is attached. (#738)
- **Wrap convertAllTimelineEvents in try-catch** - A single bad event crashes the entire conversion loop, leaving the timeline partially loaded. Now logs the error and continues. (#739)
- **Filter onKey to KeyDownEvent only** - On Windows, `onKey` receives KeyDownEvent, KeyUpEvent, and KeyRepeatEvent. Processing all types causes double-handling of key presses (e.g. backspace deletes twice). (#740)

## Test plan
- [ ] Verify update checker works correctly (no crash on preference check)
- [ ] Navigate between rooms rapidly to exercise async setState paths
- [ ] Open an empty room to verify timeline appears (firstFrame fix)
- [ ] Load a room with potentially malformed events in history
- [ ] Test keyboard input on Windows - backspace, tab completion, enter