### PR TITLE
Update mediakit dependency override  for ios and macos. (3/4)

### DIFF
--- a/commet/pubspec.yaml
+++ b/commet/pubspec.yaml
@@ -147,6 +147,20 @@ dependency_overrides:
       ref: webview-patch
       path: ./packages/desktop_webview_window
 
+  ## The media_kit macos and ios video libraries have an issue
+  ## in the published version. see: https://github.com/media-kit/media-kit/issues/709
+  ## this probably should be forked to prevent unstable updates.
+  media_kit_libs_macos_video:
+    git:
+      url: https://github.com/media-kit/media-kit
+      ref: main
+      path: libs/macos/media_kit_libs_macos_video
+  media_kit_libs_ios_video:
+    git:
+      url: https://github.com/media-kit/media-kit
+      ref: main
+      path: libs/ios/media_kit_libs_ios_video
+
 dev_dependencies: 
   drift_dev: ^2.28.0
   build_runner: ^2.4.11


### PR DESCRIPTION
This supersedes https://github.com/commetchat/commet/pull/837

Fixes an issue where mediakit will not build on apple platforms. The upstream repo has fixed the build in the source code, but have not published a new version.