### PR TITLE
Apple fixes for app launch exception, vodozemac and emoji (4/4)

### DIFF
--- a/commet/lib/client/matrix/matrix_client.dart
+++ b/commet/lib/client/matrix/matrix_client.dart
@@ -212,7 +212,7 @@ class MatrixClient extends Client {
 
   static Future<void> _checkSystem(ClientManager clientManager) async {
     try {
-      await vod.init(wasmPath: './assets/assets/vodozemac/');
+      await vodozemac.init(wasmPath: './assets/assets/vodozemac/');
       if (!vod.isInitialized()) {
         throw Exception("Vodozemac failed to initialize!");
       }

--- a/commet/lib/main.dart
+++ b/commet/lib/main.dart
@@ -217,6 +217,32 @@ Future<void> initNecessary() async {
   NeedsPostLoginInit.doPostLoginInit();
 }
 
+/// Wrapping the initialization functions in closures prevents an exception
+/// "Null check operator used on a null value". Despite the try/catch,
+/// the error does not actually occur inside of the closure now.
+/// This has the added benefit of providing a stacktrace if there is an
+/// error.
+Future<List> _loadLocalization(Locale locale) async {
+  // Wrap the localization initialization functions with a try/catch
+  // and if there is an exception print the error and stack trace.
+  Future<void> _load(dynamic Function() loadFunction) async {
+    try {
+      await loadFunction();
+    } catch (e, st) {
+      Log.e("Error loading localization: $e\n$st");
+    }
+  }
+
+  return await Future.wait<dynamic>([
+    _load(() async => UnicodeEmojis.load()),
+    if (!preferences.debugTranslations.value)
+      _load(() async => initializeMessages(locale.languageCode)),
+    if (preferences.debugTranslations.value)
+      _load(() async => initializeMessagesDebug()),
+    _load(() async => initializeDateFormatting(locale.languageCode)),
+  ]);
+}
+
 /// Initializes everything that is needed to run in GUI mode
 Future<void> initGuiRequirements() async {
   isHeadless = false;
@@ -225,13 +251,7 @@ Future<void> initGuiRequirements() async {
 
   var locale = PlatformDispatcher.instance.locale;
 
-  Future.wait([
-    UnicodeEmojis.load(),
-    if (!preferences.debugTranslations.value)
-      initializeMessages(locale.languageCode),
-    if (preferences.debugTranslations.value) initializeMessagesDebug(),
-    initializeDateFormatting(locale.languageCode),
-  ]);
+  await _loadLocalization(locale);
 
   tiamat.getAppScale = () {
     return preferences.appScale.value;

--- a/tiamat/lib/config/style/theme_common.dart
+++ b/tiamat/lib/config/style/theme_common.dart
@@ -3,6 +3,11 @@ import 'dart:io' show Platform;
 
 class ThemeCommon {
   static List<String>? fontFamilyFallback() {
+    // Apple does not render emoji with the default font
+    // instead use the system-available emoji font.
+    if (!kIsWeb && (Platform.isMacOS || Platform.isIOS)) {
+      return ["Apple Color Emoji"];
+    }
     const fonts = ["EmojiFont"];
     return fonts;
   }


### PR DESCRIPTION
This supersedes https://github.com/commetchat/commet/pull/837

- Vodozemac does not initialize unless you use the correct init method from flutter_vodozemac
- Fixes an exception that consistently occurs during app launch (probably to do with isolate task scheduling)
  - Just wrapping the async functions in closures is enough to prevent the error
  - This additionally adds a more informative error log if something does go wrong in the isolate
- For apple platforms, use system emoji, the emoji font does not render (i also tried TTF instead of OTF but it didn't make any difference)