### PR TITLE
implement MSC4440 biography support

### DIFF
--- a/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
+++ b/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
@@ -182,7 +182,7 @@ class MatrixProfile
     if (htmlPart != null) {
       return Material(
         color: Colors.transparent,
-        child: MatrixHtmlParser.parse(htmlPart["body"], client, null),
+        child: MatrixHtmlParser.parse((htmlPart["body"] as String).replaceAll("<br/></blockquote>", "</blockquote>"), client, null),
       );
     }
 

--- a/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
+++ b/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
@@ -197,10 +197,23 @@ class MatrixProfile
   }
 
   @override
-  bool get hasBio => fields.containsKey(MatrixProfileComponent.bioKey);
+  bool get hasBio =>
+      fields.containsKey(MatrixProfileComponent.bioKey) ||
+      fields.containsKey(MatrixProfileComponent.msc4440BioKey);
 
   @override
-  String? get plaintextBio => fields[MatrixProfileComponent.bioKey]?["body"];
+  String? get plaintextBio {
+    var plainTextBodyCommet = fields[MatrixProfileComponent.bioKey]?["body"];
+    List<Map<String, dynamic>>? content =
+        fields[MatrixProfileComponent.msc4440BioKey]['m.text'];
+
+    for (final item in content!) {
+      if (item['body'] != null && item['mimetype'] == null) {
+        return item['body'];
+      }
+    }
+    return plainTextBodyCommet;
+  }
 
   @override
   Future<List<ProfileBadge>> getBadges() async {
@@ -461,6 +474,27 @@ class MatrixProfileComponent implements UserProfileComponent<MatrixClient> {
   @override
   Future<void> setBio(String bio) async {
     Map<String, String> content = textToContent(bio, client);
+    
+    if (content['formatted_body'] != null && content['body'] != null) {
+      await setField(msc4440BioKey, {
+        'm.text': [
+          {'body': content['formatted_body'], 'mimetype': 'text/html'},
+          {'body': content['body']}
+        ]
+      });
+    } else if (content['formatted_body'] == null && content['body'] != null) {
+      await setField(msc4440BioKey, {
+        'm.text': [
+          {'body': content['body']}
+        ]
+      });
+    } else if (content['formatted_body'] != null && content['body'] == null) {
+      await setField(msc4440BioKey, {
+        'm.text': [
+          {'body': content['formatted_body'], 'mimetype': 'text/html'},
+        ]
+      });
+    }
 
     await setField(bioKey, content);
   }
@@ -488,6 +522,7 @@ class MatrixProfileComponent implements UserProfileComponent<MatrixClient> {
 
   @override
   Future<void> removeBio() {
+    removeField(msc4440BioKey);
     return removeField(bioKey);
   }
 

--- a/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
+++ b/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
@@ -143,8 +143,8 @@ class MatrixProfile
   Widget buildBio(BuildContext context, ThemeData theme,
       {String? overrideText}) {
     // to be compatible with both the MSC version and commet's own version
-    List<Map<String, dynamic>>? content =
-        fields[MatrixProfileComponent.msc4440BioKey]['m.text'];
+    List<dynamic>? content =
+        fields[MatrixProfileComponent.msc4440BioKey]?['m.text'];
     Map<String, dynamic>? commetBioContent =
         fields[MatrixProfileComponent.bioKey];
     if (overrideText != null) {
@@ -168,7 +168,7 @@ class MatrixProfile
         };
       }
     } else if (content is List) {
-      for (final item in content!) {
+      for (final item in content) {
         if (item['mimetype'] == "text/html") {
           htmlPart = item;
         } else if (item['body'] != null) {
@@ -205,9 +205,10 @@ class MatrixProfile
   String? get plaintextBio {
     var plainTextBodyCommet = fields[MatrixProfileComponent.bioKey]?["body"];
     List<Map<String, dynamic>>? content =
-        fields[MatrixProfileComponent.msc4440BioKey]['m.text'];
+        fields[MatrixProfileComponent.msc4440BioKey]?['m.text'];
 
-    for (final item in content!) {
+    if (content == null) return plainTextBodyCommet;
+    for (final item in content) {
       if (item['body'] != null && item['mimetype'] == null) {
         return item['body'];
       }

--- a/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
+++ b/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
@@ -143,26 +143,33 @@ class MatrixProfile
   Widget buildBio(BuildContext context, ThemeData theme,
       {String? overrideText}) {
     // to be compatible with both the MSC version and commet's own version
-    List<Map<String, dynamic>>? content = fields[MatrixProfileComponent.msc4440BioKey]['m.text'];
-    Map<String, dynamic>? commetBioContent = fields[MatrixProfileComponent.bioKey];
-    
+    List<Map<String, dynamic>>? content =
+        fields[MatrixProfileComponent.msc4440BioKey]['m.text'];
+    Map<String, dynamic>? commetBioContent =
+        fields[MatrixProfileComponent.bioKey];
+    if (overrideText != null) {
+      commetBioContent =
+          MatrixProfileComponent.textToContent(overrideText, client);
+    }
+
     Map<String, dynamic>? htmlPart;
     Map<String, dynamic>? textPart;
     if (content == null && commetBioContent != null) {
-      if (commetBioContent["formatted_body"] != null && commetBioContent["format"] == "org.matrix.custom.html"){
+      if (commetBioContent["formatted_body"] != null &&
+          commetBioContent["format"] == "org.matrix.custom.html") {
         htmlPart = {
-          "body" : commetBioContent["formatted_body"],
-          "mimetype" : "text/html",
+          "body": commetBioContent["formatted_body"],
+          "mimetype": "text/html",
         };
       }
-      if (commetBioContent["body"] != null){
+      if (commetBioContent["body"] != null) {
         textPart = {
-          "body" : commetBioContent["body"],
+          "body": commetBioContent["body"],
         };
       }
-    } else if (content is List){
+    } else if (content is List) {
       for (final item in content!) {
-        if(item['mimetype'] == "text/html"){
+        if (item['mimetype'] == "text/html") {
           htmlPart = item;
         } else if (item['body'] != null) {
           textPart = item;

--- a/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
+++ b/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
@@ -204,7 +204,7 @@ class MatrixProfile
   @override
   String? get plaintextBio {
     var plainTextBodyCommet = fields[MatrixProfileComponent.bioKey]?["body"];
-    List<Map<String, dynamic>>? content =
+    List<dynamic>? content =
         fields[MatrixProfileComponent.msc4440BioKey]?['m.text'];
 
     if (content == null) return plainTextBodyCommet;

--- a/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
+++ b/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
@@ -142,25 +142,47 @@ class MatrixProfile
   @override
   Widget buildBio(BuildContext context, ThemeData theme,
       {String? overrideText}) {
-    Map<String, dynamic>? content = fields[MatrixProfileComponent.bioKey];
-
-    if (overrideText != null) {
-      content = MatrixProfileComponent.textToContent(overrideText, client);
+    // to be compatible with both the MSC version and commet's own version
+    List<Map<String, dynamic>>? content = fields[MatrixProfileComponent.msc4440BioKey]['m.text'];
+    Map<String, dynamic>? commetBioContent = fields[MatrixProfileComponent.bioKey];
+    
+    Map<String, dynamic>? htmlPart;
+    Map<String, dynamic>? textPart;
+    if (content == null && commetBioContent != null) {
+      if (commetBioContent["formatted_body"] != null && commetBioContent["format"] == "org.matrix.custom.html"){
+        htmlPart = {
+          "body" : commetBioContent["formatted_body"],
+          "mimetype" : "text/html",
+        };
+      }
+      if (commetBioContent["body"] != null){
+        textPart = {
+          "body" : commetBioContent["body"],
+        };
+      }
+    } else if (content is List){
+      for (final item in content!) {
+        if(item['mimetype'] == "text/html"){
+          htmlPart = item;
+        } else if (item['body'] != null) {
+          textPart = item;
+        }
+      }
     }
 
-    if (content == null) return Container();
+    if (htmlPart == null && textPart == null) return Container();
 
-    if (content["format"] == "org.matrix.custom.html") {
+    if (htmlPart != null) {
       return Material(
         color: Colors.transparent,
-        child: MatrixHtmlParser.parse(content["formatted_body"], client, null),
+        child: MatrixHtmlParser.parse(htmlPart["body"], client, null),
       );
     }
 
     return Material(
       color: Colors.transparent,
       child: Text(
-        content["body"],
+        textPart?["body"],
         style: theme.textTheme.bodyMedium
             ?.copyWith(color: theme.colorScheme.onSurface),
       ),
@@ -331,6 +353,7 @@ class MatrixProfileComponent implements UserProfileComponent<MatrixClient> {
   static const String bannerKey = "chat.commet.profile_banner";
   static const String colorSchemeKey = "chat.commet.profile_color_scheme";
   static const String bioKey = "chat.commet.profile_bio";
+  static const String msc4440BioKey = "gay.fomx.biography";
   static const String badgeKey = "chat.commet.profile_badges";
   static const String statusKey = "chat.commet.profile_status";
   static const String pronounsKey = "io.fsky.nyx.pronouns";

--- a/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
+++ b/commet/lib/client/matrix/components/profile/matrix_profile_component.dart
@@ -475,7 +475,7 @@ class MatrixProfileComponent implements UserProfileComponent<MatrixClient> {
   @override
   Future<void> setBio(String bio) async {
     Map<String, String> content = textToContent(bio, client);
-    
+
     if (content['formatted_body'] != null && content['body'] != null) {
       await setField(msc4440BioKey, {
         'm.text': [


### PR DESCRIPTION
Implements [MSC4440](https://github.com/matrix-org/matrix-spec-proposals/pull/4440) as alternative and standardised format to Commets own biography field.
(most of the code was written by @dozro, but i took over and fixed it up)

Currently, this will still set Commets own key in addition to MSC4440 for backwards compatibility with older versions of Commet.
However, if an MSC4440 field is set, it will prefer rendering that one over the Commet one (which shouldn't break any "legacy" biographies, as they're only set on the Commet field and the new one won't exist)

Ideally, after a few versions/weeks/months of this being merged and released, no longer setting the Commet biography and removing its profile key seems ideal, and after some time later, fully removing it. Though that's out of scope for this PR :3
