### PR TITLE
full-tab / window screenshare

### DIFF
--- a/commet/lib/ui/organisms/call_view/call_view.dart
+++ b/commet/lib/ui/organisms/call_view/call_view.dart
@@ -3,7 +3,6 @@ import 'package:commet/client/components/voip/voip_session.dart';
 import 'package:commet/client/components/voip/voip_stream.dart';
 import 'package:commet/client/room.dart';
 import 'package:commet/config/layout_config.dart';
-import 'package:commet/ui/atoms/lightbox.dart';
 import 'package:commet/ui/layout/bento.dart';
 import 'package:commet/ui/organisms/call_view/voip_fullscreen_stream_view.dart';
 import 'package:commet/ui/organisms/call_view/voip_stream_view.dart';
@@ -225,12 +224,27 @@ class _CallViewState extends State<CallView> {
                   widget.currentSession,
                   borderColor: Colors.white,
                   onFullscreen: () {
-                    Lightbox.show(context,
-                        aspectRatio: mainStream!.aspectRatio,
-                        customWidget: VoipFullscreenStreamView(
-                          session: widget.currentSession,
-                          stream: mainStream!,
-                        ));
+                    Navigator.push(
+                      context,
+                      PageRouteBuilder(
+                        pageBuilder: (context, animation, secondaryAnimation) =>
+                            Scaffold(
+                          backgroundColor: Colors.black,
+                          body: VoipFullscreenStreamView(
+                            session: widget.currentSession,
+                            stream: mainStream!,
+                          ),
+                        ),
+                        transitionsBuilder:
+                            (context, animation, secondaryAnimation, child) {
+                          return FadeTransition(
+                            opacity: animation,
+                            child: child,
+                          );
+                        },
+                        fullscreenDialog: true,
+                      ),
+                    );
                   },
                   fit: BoxFit.contain,
                   key: ValueKey(
@@ -260,12 +274,27 @@ class _CallViewState extends State<CallView> {
                         : BoxFit.cover,
                     widget.currentSession,
                     onFullscreen: () {
-                      Lightbox.show(context,
-                          aspectRatio: e.aspectRatio,
-                          customWidget: VoipFullscreenStreamView(
-                            session: widget.currentSession,
-                            stream: e,
-                          ));
+                      Navigator.push(
+                        context,
+                        PageRouteBuilder(
+                          pageBuilder: (context, animation, secondaryAnimation) =>
+                              Scaffold(
+                            backgroundColor: Colors.black,
+                            body: VoipFullscreenStreamView(
+                              session: widget.currentSession,
+                              stream: e,
+                            ),
+                          ),
+                          transitionsBuilder:
+                              (context, animation, secondaryAnimation, child) {
+                            return FadeTransition(
+                              opacity: animation,
+                              child: child,
+                            );
+                          },
+                          fullscreenDialog: true,
+                        ),
+                      );
                     },
                   )))
               .toList()),

--- a/commet/lib/ui/organisms/call_view/voip_fullscreen_stream_view.dart
+++ b/commet/lib/ui/organisms/call_view/voip_fullscreen_stream_view.dart
@@ -32,7 +32,6 @@ class _VoipFullscreenStreamViewState extends State<VoipFullscreenStreamView> {
   @override
   Widget build(BuildContext context) {
     return Stack(
-      alignment: Alignment.bottomCenter,
       children: [
         LayoutBuilder(
           builder: (context, constraints) {
@@ -41,6 +40,7 @@ class _VoipFullscreenStreamViewState extends State<VoipFullscreenStreamView> {
                 widget.stream,
                 widget.session,
                 canFullscreen: false,
+                onFullscreen: () {Navigator.of(context).pop();},
               ),
               onHover: (event) {
                 final width = constraints.maxWidth;

--- a/commet/lib/ui/organisms/call_view/voip_stream_view.dart
+++ b/commet/lib/ui/organisms/call_view/voip_stream_view.dart
@@ -90,8 +90,7 @@ class _VoipStreamViewState extends State<VoipStreamView>
                           BoxDecoration(borderRadius: BorderRadius.circular(8)),
                       child: buildDefault()),
                 ),
-                if (widget.canFullscreen &&
-                        widget.stream.type == VoipStreamType.video ||
+                if (widget.stream.type == VoipStreamType.video ||
                     widget.stream.type == VoipStreamType.screenshare)
                   SizedBox(
                     width: 40,


### PR DESCRIPTION
Change "fullscreen" behavior to display video / screenshare stream as "full-app"

Tested Windows and Web

Windows App - Wide Content
<img width="2560" height="1440" alt="android-wide" src="https://github.com/user-attachments/assets/6bb8f053-c2ac-4932-807f-1a166267796f" />

Windows App - Tall Content
<img width="2560" height="1440" alt="windows-tall" src="https://github.com/user-attachments/assets/711e9c2a-3d82-4235-9599-7194e0beaa74" />

Windows Browser - Tall Content
<img width="2560" height="1440" alt="tall" src="https://github.com/user-attachments/assets/3907ea3a-ee97-4fb8-ab63-c17c34500258" />

Windows Browser - Wide Content
<img width="2560" height="1440" alt="wide" src="https://github.com/user-attachments/assets/86fedb65-a79c-4189-98cd-72edbdd54770" />

Fixes
https://github.com/commetchat/commet/issues/883

Maybe (couldn't setup android dev environment)
https://github.com/commetchat/commet/issues/844