### PR TITLE
show last message instead of last event for previews

### DIFF
--- a/commet/lib/client/matrix/matrix_room.dart
+++ b/commet/lib/client/matrix/matrix_room.dart
@@ -41,6 +41,7 @@ import 'package:commet/client/member.dart';
 import 'package:commet/client/permissions.dart';
 import 'package:commet/client/role.dart';
 import 'package:commet/client/timeline_events/timeline_event.dart';
+import 'package:commet/client/timeline_events/timeline_event_emote.dart';
 import 'package:commet/client/timeline_events/timeline_event_message.dart';
 import 'package:commet/client/timeline_events/timeline_event_sticker.dart';
 import 'package:commet/config/build_config.dart';
@@ -110,6 +111,9 @@ class MatrixRoom extends Room {
 
   @override
   TimelineEvent? lastEvent;
+
+  @override
+  TimelineEvent? lastMessage;
 
   @override
   Iterable<String> get memberIds =>
@@ -223,6 +227,10 @@ class MatrixRoom extends Room {
 
     if (latest != null) {
       lastEvent = convertEvent(latest);
+
+      if (latest.type == matrix.EventTypes.Message) {
+        lastMessage = lastEvent;
+      }
     }
 
     updateAvatar();
@@ -283,6 +291,18 @@ class MatrixRoom extends Room {
       } else if (event.originServerTs.isAfter(lastEvent!.originServerTs)) {
         lastEvent = event;
         _onUpdate.add(null);
+      }
+
+      if (event is TimelineEventMessage ||
+          event is TimelineEventSticker ||
+          event is TimelineEventEmote) {
+        if (lastMessage == null) {
+          lastMessage = event;
+          _onUpdate.add(null);
+        } else if (event.originServerTs.isAfter(lastMessage!.originServerTs)) {
+          lastMessage = event;
+          _onUpdate.add(null);
+        }
       }
     }
   }

--- a/commet/lib/client/matrix_background/matrix_background_room.dart
+++ b/commet/lib/client/matrix_background/matrix_background_room.dart
@@ -225,6 +225,9 @@ class MatrixBackgroundRoom implements Room {
   TimelineEvent<Client>? get lastEvent => throw UnimplementedError();
 
   @override
+  TimelineEvent? get lastMessage => throw UnimplementedError();
+
+  @override
   DateTime get lastEventTimestamp => throw UnimplementedError();
 
   @override

--- a/commet/lib/client/room.dart
+++ b/commet/lib/client/room.dart
@@ -216,6 +216,9 @@ abstract class Room {
   /// The last known event in the room timeline
   TimelineEvent? get lastEvent;
 
+  /// The last message in the room timeline (filters out non-message events)
+  TimelineEvent? get lastMessage;
+
   T? getComponent<T extends RoomComponent>();
 
   List<T> getAllComponents<T extends RoomComponent<Client, Room>>();

--- a/commet/lib/ui/navigation/quick_switcher.dart
+++ b/commet/lib/ui/navigation/quick_switcher.dart
@@ -57,8 +57,8 @@ class QuickSwitcherSearchItemRoom implements QuickSwitcherSearchItem {
 
   @override
   Widget build(BuildContext context) {
-    var sender = room.lastEvent != null
-        ? room.getMemberOrFallback(room.lastEvent!.senderId)
+    var sender = room.lastMessage != null
+        ? room.getMemberOrFallback(room.lastMessage!.senderId)
         : null;
 
     return RoomPanel(
@@ -68,7 +68,7 @@ class QuickSwitcherSearchItemRoom implements QuickSwitcherSearchItem {
       avatar: room.avatar,
       recentEventSender: sender?.displayName,
       recentEventSenderColor: sender?.defaultColor,
-      body: room.lastEvent?.plainTextBody,
+      body: room.lastMessage?.plainTextBody,
     );
   }
 
@@ -195,17 +195,17 @@ class _QuickSwitcherState extends State<QuickSwitcher> {
                     displayName: room.displayName,
                     color: room.defaultColor,
                     avatar: room.avatar,
-                    recentEventSender: room.lastEvent != null
+                    recentEventSender: room.lastMessage != null
                         ? room
-                            .getMemberOrFallback(room.lastEvent!.senderId)
+                            .getMemberOrFallback(room.lastMessage!.senderId)
                             .displayName
                         : null,
-                    recentEventSenderColor: room.lastEvent != null
+                    recentEventSenderColor: room.lastMessage != null
                         ? room
-                            .getMemberOrFallback(room.lastEvent!.senderId)
+                            .getMemberOrFallback(room.lastMessage!.senderId)
                             .defaultColor
                         : null,
-                    body: room.lastEvent?.plainTextBody,
+                    body: room.lastMessage?.plainTextBody,
                   )
               ],
             ))

--- a/commet/lib/ui/organisms/home_screen/home_screen_view.dart
+++ b/commet/lib/ui/organisms/home_screen/home_screen_view.dart
@@ -107,14 +107,14 @@ class HomeScreenView extends StatelessWidget {
               displayName: room.displayName,
               avatar: room.avatar,
               color: room.defaultColor,
-              body: room.lastEvent?.plainTextBody,
-              recentEventSender: room.lastEvent != null
+              body: room.lastMessage?.plainTextBody,
+              recentEventSender: room.lastMessage != null
                   ? room
-                      .getMemberOrFallback(room.lastEvent!.senderId)
+                      .getMemberOrFallback(room.lastMessage!.senderId)
                       .displayName
                   : null,
-              recentEventSenderColor: room.lastEvent != null
-                  ? room.getColorOfUser(room.lastEvent!.senderId)
+              recentEventSenderColor: room.lastMessage != null
+                  ? room.getColorOfUser(room.lastMessage!.senderId)
                   : null,
               onTap: () => onRoomClicked?.call(room),
               showUserAvatar: clientManager.rooms
@@ -147,14 +147,14 @@ class HomeScreenView extends StatelessWidget {
                   displayName: room.displayName,
                   avatar: room.avatar,
                   color: room.defaultColor,
-                  body: room.lastEvent?.plainTextBody,
-                  recentEventSender: room.lastEvent != null
+                  body: room.lastMessage?.plainTextBody,
+                  recentEventSender: room.lastMessage != null
                       ? room
-                          .getMemberOrFallback(room.lastEvent!.senderId)
+                          .getMemberOrFallback(room.lastMessage!.senderId)
                           .displayName
                       : null,
-                  recentEventSenderColor: room.lastEvent != null
-                      ? room.getColorOfUser(room.lastEvent!.senderId)
+                  recentEventSenderColor: room.lastMessage != null
+                      ? room.getColorOfUser(room.lastMessage!.senderId)
                       : null,
                   onTap: () => onRoomClicked?.call(room),
                   showUserAvatar: clientManager.rooms

--- a/commet/lib/ui/organisms/space_summary/space_summary_view.dart
+++ b/commet/lib/ui/organisms/space_summary/space_summary_view.dart
@@ -564,12 +564,12 @@ class SpaceSummaryViewState extends State<SpaceSummaryView> {
                     widget.onRoomTap?.call(room);
                   }
                 : null,
-        body: room.lastEvent?.plainTextBody,
-        recentEventSender: room.lastEvent != null
-            ? room.getMemberOrFallback(room.lastEvent!.senderId).displayName
+        body: room.lastMessage?.plainTextBody,
+        recentEventSender: room.lastMessage != null
+            ? room.getMemberOrFallback(room.lastMessage!.senderId).displayName
             : null,
-        recentEventSenderColor: room.lastEvent != null
-            ? room.getColorOfUser(room.lastEvent!.senderId)
+        recentEventSenderColor: room.lastMessage != null
+            ? room.getColorOfUser(room.lastMessage!.senderId)
             : null,
       );
     } else if (item case SpaceChildSpace _) {


### PR DESCRIPTION
add lastMessage as a property to Rooms

Change home screen, quick switcher, and space summary to use lastMessage instead of lastEvent

<img width="1904" height="893" alt="image" src="https://github.com/user-attachments/assets/bb18906e-942f-4d8c-8176-91c7352e067a" />

A natural extension of https://github.com/commetchat/commet/pull/904 IMO

Not sure if this should be configurable, I personally wouldn't care about state events, but maybe someone else will?