### PR TITLE
Improve URL preview embeds

### DIFF
--- a/commet/lib/cache/file_provider.dart
+++ b/commet/lib/cache/file_provider.dart
@@ -46,3 +46,32 @@ class SystemFileProvider implements FileProvider {
     return file.readAsBytes();
   }
 }
+
+class WebFileProvider implements FileProvider {
+  Uri url;
+
+  @override
+  String get fileIdentifier => url.toString();
+
+  @override
+  Future<Uri?> resolve() async {
+    throw UnimplementedError();
+    //   return file.uri;
+  }
+
+  @override
+  Future<void> save(String filepath) {
+    throw UnimplementedError();
+  }
+
+  WebFileProvider(this.url);
+
+  @override
+  Stream<DownloadProgress>? get onProgressChanged => null;
+
+  @override
+  Future<Uint8List?> getFileData() {
+    throw UnimplementedError();
+    // return file.readAsBytes();
+  }
+}

--- a/commet/lib/client/attachment.dart
+++ b/commet/lib/client/attachment.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:mime/mime.dart' as mime;
 
 abstract class Attachment {
-  late String name;
+  late String? name;
 }
 
 abstract class ProcessedAttachment {}
@@ -59,7 +59,7 @@ class PendingFileAttachment {
 
 class FileAttachment implements Attachment {
   @override
-  String name;
+  String? name;
   int? fileSize;
   String? mimeType;
   FileProvider file;
@@ -94,10 +94,13 @@ class VideoAttachment extends FileAttachment {
   double get aspectRatio =>
       (width != null && height != null) ? (width! / height!) : 1;
 
+  final Uri? streamUrl;
+
   VideoAttachment(super.file,
-      {required super.name,
+      {super.name,
       required super.mimeType,
       this.thumbnail,
+      this.streamUrl,
       this.width,
       this.height,
       this.duration,

--- a/commet/lib/client/components/url_preview/url_preview_component.dart
+++ b/commet/lib/client/components/url_preview/url_preview_component.dart
@@ -1,3 +1,4 @@
+import 'package:commet/client/attachment.dart';
 import 'package:commet/client/client.dart';
 import 'package:commet/client/components/component.dart';
 import 'package:commet/client/timeline_events/timeline_event.dart';
@@ -23,18 +24,28 @@ abstract class UrlPreviewComponent<T extends Client> implements Component<T> {
       UrlPreviewData(Uri.new(), title: "Unable to get url preview ");
 }
 
+enum UrlDestinationType {
+  page,
+  video,
+  image,
+}
+
 class UrlPreviewData {
   final Uri uri;
   final String? siteName;
   final String? title;
   final String? description;
   final ImageProvider? image;
+  final VideoAttachment? video;
+  final UrlDestinationType? type;
 
   const UrlPreviewData(
     this.uri, {
     this.siteName,
     this.title,
     this.description,
+    this.type,
     this.image,
+    this.video,
   });
 }

--- a/commet/lib/client/matrix/components/threads/matrix_thread_timeline.dart
+++ b/commet/lib/client/matrix/components/threads/matrix_thread_timeline.dart
@@ -319,4 +319,12 @@ class MatrixThreadTimeline implements Timeline {
     var e = event as MatrixTimelineEvent;
     return e.event.getDisplayEvent(mainRoomTimeline.matrixTimeline!).redacted;
   }
+
+  @override
+  String getDisplayId(TimelineEvent<Client> event) {
+    var e = event as MatrixTimelineEvent;
+    var ev = e.event.getDisplayEvent(mainRoomTimeline.matrixTimeline!);
+
+    return "thread-${threadRootId}-${event.eventId}-${ev.eventId}";
+  }
 }

--- a/commet/lib/client/matrix/components/url_preview/matrix_url_preview_component.dart
+++ b/commet/lib/client/matrix/components/url_preview/matrix_url_preview_component.dart
@@ -1,3 +1,5 @@
+import 'package:commet/cache/file_provider.dart';
+import 'package:commet/client/attachment.dart';
 import 'package:commet/client/components/url_preview/url_preview_component.dart';
 import 'package:commet/client/matrix/matrix_client.dart';
 import 'package:commet/client/matrix/matrix_mxc_image_provider.dart';
@@ -175,6 +177,20 @@ class MatrixUrlPreviewComponent implements UrlPreviewComponent<MatrixClient> {
     var siteName = response['og:site_name'] as String?;
     var imageUrl = response['og:image'] as String?;
     var description = response['og:description'] as String?;
+    var video =
+        (response['og:video:secure_url'] ?? response["og:video"]) as String?;
+    var videoType = response['og:video:type'] as String?;
+
+    int? videoWidth = null;
+    int? videoHeight = null;
+
+    var videoWidthStr = response['og:video:width'] as String?;
+    var videoHeightStr = response['og:video:height'] as String?;
+
+    if (videoHeightStr != null && videoWidthStr != null) {
+      videoWidth = int.tryParse(videoWidthStr);
+      videoHeight = int.tryParse(videoHeightStr);
+    }
 
     var type = response["og:image:type"] as String?;
     if (type != null) {
@@ -196,6 +212,29 @@ class MatrixUrlPreviewComponent implements UrlPreviewComponent<MatrixClient> {
       }
     }
 
+    var destinationType = UrlDestinationType.page;
+    VideoAttachment? videoAttachment;
+
+    if (video != null) {
+      destinationType = UrlDestinationType.video;
+    }
+
+    if (video is String &&
+        videoType != null &&
+        (Mime.videoTypes.contains(videoType) ||
+            Mime.videoStreamTypes.contains(videoType))) {
+      var uri = Uri.parse(video);
+
+      if (uri.scheme == "https") {
+        videoAttachment = VideoAttachment(WebFileProvider(uri),
+            width: videoWidth?.toDouble(),
+            height: videoHeight?.toDouble(),
+            streamUrl: uri,
+            thumbnail: image,
+            mimeType: videoType);
+      }
+    }
+
     if (description != null) {
       description = description.replaceAll("\n", "    ");
     }
@@ -204,6 +243,8 @@ class MatrixUrlPreviewComponent implements UrlPreviewComponent<MatrixClient> {
         siteName: siteName,
         title: title,
         image: image,
+        video: videoAttachment,
+        type: destinationType,
         description: description);
   }
 }

--- a/commet/lib/client/matrix/matrix_timeline.dart
+++ b/commet/lib/client/matrix/matrix_timeline.dart
@@ -205,4 +205,12 @@ class MatrixTimeline extends Timeline {
     var e = event as MatrixTimelineEvent;
     return e.event.getDisplayEvent(_matrixTimeline!).redacted;
   }
+
+  @override
+  String getDisplayId(TimelineEvent<Client> event) {
+    var e = event as MatrixTimelineEvent;
+    var ev = e.event.getDisplayEvent(matrixTimeline!);
+
+    return "${event.eventId}-${ev.eventId}";
+  }
 }

--- a/commet/lib/client/timeline.dart
+++ b/commet/lib/client/timeline.dart
@@ -116,6 +116,8 @@ abstract class Timeline {
     _eventsDict[events[index].eventId] = events[index];
   }
 
+  String getDisplayId(TimelineEvent event);
+
   bool canDeleteEvent(TimelineEvent event);
 
   void deleteEvent(TimelineEvent event);

--- a/commet/lib/config/preferences.dart
+++ b/commet/lib/config/preferences.dart
@@ -7,6 +7,7 @@ import 'package:commet/config/platform_utils.dart';
 import 'package:commet/config/preferences/bool_preference.dart';
 import 'package:commet/config/preferences/double_preference.dart';
 import 'package:commet/config/preferences/preference.dart';
+import 'package:commet/config/preferences/string_list_preference.dart';
 import 'package:commet/config/preferences/string_preference.dart';
 import 'package:commet/config/theme_config.dart';
 import 'package:commet/main.dart';
@@ -407,4 +408,7 @@ class Preferences {
 
   NullableStringPreference lastDownloadLocation =
       NullableStringPreference("last_download_location", defaultValue: null);
+
+  StringListPreference allowedRemoteVideoHosts =
+      StringListPreference("allowed_remote_video_hosts", defaultValue: []);
 }

--- a/commet/lib/config/preferences/string_list_preference.dart
+++ b/commet/lib/config/preferences/string_list_preference.dart
@@ -1,0 +1,37 @@
+import 'package:commet/config/preferences/preference.dart';
+
+class StringListPreference extends Preference<List<String>> {
+  StringListPreference(super.key, {required super.defaultValue})
+      : super(
+            getter: () =>
+                Preference.preferences?.getStringList(key) ?? List.empty(),
+            setter: (v) async {
+              await Preference.preferences?.setStringList(key, v);
+            });
+
+  void add(String value) {
+    var values = Preference.preferences?.getStringList(key);
+
+    var newValues = values == null
+        ? List<String>.empty(growable: true)
+        : List<String>.from(values, growable: true);
+
+    if (!newValues.contains(value)) {
+      newValues.add(value);
+    }
+
+    Preference.preferences?.setStringList(key, newValues);
+  }
+
+  void remove(String value) {
+    var values = Preference.preferences?.getStringList(key);
+
+    var newValues = values == null
+        ? List<String>.empty(growable: true)
+        : List<String>.from(values, growable: true);
+
+    newValues.remove(value);
+
+    Preference.preferences?.setStringList(key, newValues);
+  }
+}

--- a/commet/lib/ui/atoms/message_attachment.dart
+++ b/commet/lib/ui/atoms/message_attachment.dart
@@ -14,10 +14,14 @@ import 'package:tiamat/tiamat.dart' as tiamat;
 
 class MessageAttachment extends StatefulWidget {
   const MessageAttachment(this.attachment,
-      {super.key, this.ignorePointer = false, this.previewMedia = false});
+      {super.key,
+      this.ignorePointer = false,
+      this.constrainSize = true,
+      this.previewMedia = false});
   final Attachment attachment;
   final bool ignorePointer;
   final bool previewMedia;
+  final bool constrainSize;
   @override
   State<MessageAttachment> createState() => _MessageAttachmentState();
 }
@@ -100,20 +104,24 @@ class _MessageAttachmentState extends State<MessageAttachment> {
 
   Widget buildVideo() {
     var attachment = widget.attachment as VideoAttachment;
+    bool showInfo =
+        widget.attachment.name != null && attachment.fileSize != null;
 
+    double height = 160;
     return ClipRRect(
       borderRadius: BorderRadius.circular(10),
       child: SizedBox(
-        height: 200 + 30,
-        width: attachment.aspectRatio * 200,
+        height: widget.constrainSize ? height + (showInfo ? 30 : 0) : null,
+        width: widget.constrainSize ? attachment.aspectRatio * height : null,
         child: Panel(
             mainAxisSize: MainAxisSize.min,
-            header:
-                "${attachment.name} ${attachment.fileSize != null ? "- ${TextUtils.readableFileSize(attachment.fileSize!)}" : ""}",
+            header: showInfo
+                ? "${attachment.name} ${attachment.fileSize != null ? "- ${TextUtils.readableFileSize(attachment.fileSize!)}" : ""}"
+                : null,
             mode: TileType.surfaceContainerLow,
             padding: 0,
             child: SizedBox(
-                height: 200,
+                height: height,
                 width: 500,
                 child: AspectRatio(
                     aspectRatio: attachment.aspectRatio,
@@ -121,6 +129,7 @@ class _MessageAttachmentState extends State<MessageAttachment> {
                         ? null
                         : VideoPlayer(
                             attachment.file,
+                            streamUrl: attachment.streamUrl,
                             thumbnail: attachment.thumbnail,
                             fileName: attachment.name,
                             doThumbnail: true,
@@ -162,7 +171,7 @@ class _MessageAttachmentState extends State<MessageAttachment> {
     });
   }
 
-  Widget buildFile(IconData icon, String fileName, int? fileSize) {
+  Widget buildFile(IconData icon, String? fileName, int? fileSize) {
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(10),
@@ -187,7 +196,7 @@ class _MessageAttachmentState extends State<MessageAttachment> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         tiamat.Text.labelEmphasised(
-                          fileName,
+                          fileName ?? "unnamed",
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),

--- a/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
+++ b/commet/lib/ui/molecules/room_timeline_widget/room_timeline_widget_view.dart
@@ -159,6 +159,12 @@ class RoomTimelineWidgetViewState extends State<RoomTimelineWidgetView> {
         scrollToBottom();
 
         widget.markAsRead?.call(timeline.events[0]);
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          scrollToBottom();
+
+          widget.markAsRead?.call(timeline.events[0]);
+        });
       }
 
       if (preferences.messageEffectsEnabled.value) {

--- a/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_message.dart
+++ b/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_message.dart
@@ -78,6 +78,7 @@ class _TimelineEventViewMessageState extends State<TimelineEventViewMessage>
 
   Widget? formattedContent;
   String? body;
+  String? displayId;
   ImageProvider? senderAvatar;
   List<Attachment>? attachments;
   ImageProvider? sticker;
@@ -210,7 +211,7 @@ class _TimelineEventViewMessageState extends State<TimelineEventViewMessage>
       loadEventState(newIndex);
     });
 
-    for (var key in [reactionsKey, urlPreviewsKey]) {
+    for (var key in [reactionsKey]) {
       if (key.currentState is TimelineEventViewWidget) {
         (key.currentState as TimelineEventViewWidget).update(newIndex);
       }
@@ -228,6 +229,16 @@ class _TimelineEventViewMessageState extends State<TimelineEventViewMessage>
   void loadStateFromEvent(TimelineEvent event) {
     showSender = shouldShowSender(index);
     var room = widget.room ?? widget.timeline?.room;
+
+    bool didContentChange = true;
+
+    if (widget.timeline != null) {
+      var did = widget.timeline!.getDisplayId(event);
+      if (did == displayId) {
+        didContentChange = false;
+      }
+      displayId = did;
+    }
 
     var sender = room!.getMemberOrFallback(event.senderId);
     eventId = event.eventId;
@@ -282,11 +293,14 @@ class _TimelineEventViewMessageState extends State<TimelineEventViewMessage>
       return;
     }
 
-    var content = event.buildFormattedContent(timeline: widget.timeline);
-    if (content == null) {
-      formattedContent = null;
-    } else {
-      formattedContent = Container(key: GlobalKey(), child: content);
+    if (didContentChange) {
+      var content = event.buildFormattedContent(timeline: widget.timeline);
+
+      if (content == null) {
+        formattedContent = null;
+      } else {
+        formattedContent = Container(key: GlobalKey(), child: content);
+      }
     }
 
     attachments = event.attachments;

--- a/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_url_previews.dart
+++ b/commet/lib/ui/molecules/timeline_events/events/timeline_event_view_url_previews.dart
@@ -37,17 +37,14 @@ class _TimelineEventViewUrlPreviewsState
     if (data == UrlPreviewComponent.invalidPreviewData) return Container();
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(0, 2, 40, 2),
-      child: (loading || data != null)
-          ? UrlPreviewWidget(
-              key: key,
-              data,
-              onTap: () {
-                LinkUtils.open(data!.uri, context: context);
-              },
-            )
-          : Container(),
-    );
+        padding: const EdgeInsets.fromLTRB(0, 2, 40, 2),
+        child: UrlPreviewWidget(
+          key: key,
+          data,
+          onTap: () {
+            LinkUtils.open(data!.uri, context: context);
+          },
+        ));
   }
 
   @override

--- a/commet/lib/ui/molecules/url_preview_widget.dart
+++ b/commet/lib/ui/molecules/url_preview_widget.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
 
 import 'package:commet/client/components/url_preview/url_preview_component.dart';
+import 'package:commet/ui/atoms/lightbox.dart';
+import 'package:commet/ui/atoms/message_attachment.dart';
 import 'package:commet/ui/atoms/shimmer_loading.dart';
 import 'package:flutter/material.dart';
 import 'package:tiamat/atoms/tile.dart';
@@ -54,17 +56,31 @@ class _UrlPreviewWidgetState extends State<UrlPreviewWidget> {
                   children: [
                     ConstrainedBox(
                       constraints:
-                          const BoxConstraints.tightFor(height: 70, width: 500),
+                          const BoxConstraints(maxWidth: 300, maxHeight: 240),
                       child: widget.data == null
                           ? buildLoadingDisplay()
-                          : Row(
+                          : Column(
                               mainAxisSize: MainAxisSize.min,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              mainAxisAlignment: MainAxisAlignment.start,
                               children: [
-                                if (widget.data!.image != null) image(),
-                                const SizedBox(
-                                  width: 10,
-                                ),
-                                body(context)
+                                Align(
+                                    alignment: Alignment.topLeft,
+                                    child: body(context)),
+                                if (hasBody)
+                                  const SizedBox(
+                                    width: 10,
+                                    height: 10,
+                                  ),
+                                if (widget.data!.image != null &&
+                                    widget.data?.video == null)
+                                  Flexible(child: image()),
+                                if (widget.data!.video != null)
+                                  MessageAttachment(
+                                    previewMedia: true,
+                                    widget.data!.video!,
+                                    constrainSize: false,
+                                  )
                               ],
                             ),
                     )
@@ -81,52 +97,55 @@ class _UrlPreviewWidgetState extends State<UrlPreviewWidget> {
     return Shimmer(
       child: ShimmerLoading(
         isLoading: true,
-        child: Row(
-          children: [
-            ClipRRect(
-                borderRadius: BorderRadius.circular(4),
-                child: ConstrainedBox(
-                    constraints:
-                        const BoxConstraints(maxHeight: 70, maxWidth: 100),
-                    child: Container(
-                      color: color,
-                    ))),
-            const SizedBox(
-              width: 10,
-            ),
-            Flexible(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  Container(
-                    height: 14,
-                    width: titleWidth,
-                    decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(4), color: color),
-                  ),
-                  const SizedBox(
-                    height: 8,
-                  ),
-                  Container(
-                    height: 10,
-                    width: bodyWidth1,
-                    decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(4), color: color),
-                  ),
-                  const SizedBox(
-                    height: 5,
-                  ),
-                  Container(
-                    height: 10,
-                    width: bodyWidth2,
-                    decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(4), color: color),
-                  ),
-                ],
-              ),
-            )
-          ],
+        child: SizedBox(
+          height: 300,
+          child: Row(
+            children: [
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    Container(
+                      height: 14,
+                      width: titleWidth,
+                      decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(4), color: color),
+                    ),
+                    const SizedBox(
+                      height: 8,
+                    ),
+                    Container(
+                      height: 10,
+                      width: bodyWidth1,
+                      decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(4), color: color),
+                    ),
+                    const SizedBox(
+                      height: 5,
+                    ),
+                    Container(
+                      height: 10,
+                      width: bodyWidth2,
+                      decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(4), color: color),
+                    ),
+                    SizedBox(
+                      height: 8,
+                    ),
+                    ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: ConstrainedBox(
+                            constraints: const BoxConstraints(
+                                maxHeight: 180, maxWidth: 300),
+                            child: Container(
+                              color: color,
+                            ))),
+                  ],
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );
@@ -135,48 +154,57 @@ class _UrlPreviewWidgetState extends State<UrlPreviewWidget> {
   Widget image() {
     return ClipRRect(
       borderRadius: BorderRadius.circular(4),
-      child: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 70, maxWidth: 100),
-          child: Image(
-            image: widget.data!.image!,
-            filterQuality: FilterQuality.medium,
-          )),
+      child: InkWell(
+        onTap: widget.data?.type != UrlDestinationType.video
+            ? () {
+                Lightbox.show(context, image: widget.data!.image);
+              }
+            : null,
+        child: Image(
+          image: widget.data!.image!,
+          filterQuality: FilterQuality.medium,
+          fit: BoxFit.cover,
+        ),
+      ),
     );
   }
 
+  bool get hasBody =>
+      widget.data?.siteName != null ||
+      widget.data?.title != null ||
+      widget.data?.description != null;
+
   Widget body(BuildContext context) {
-    return Flexible(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (widget.data!.siteName != null)
-            tiamat.Text.labelLow(
-              widget.data!.siteName!,
-              maxLines: 1,
-              overflow: TextOverflow.fade,
-            ),
-          Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (widget.data!.title != null)
-                tiamat.Text.labelEmphasised(
-                  widget.data!.title!,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              if (widget.data!.description != null)
-                tiamat.Text.tiny(
-                  widget.data!.description!,
-                  maxLines: 2,
-                  color: Theme.of(context).colorScheme.secondary,
-                  overflow: TextOverflow.ellipsis,
-                )
-            ],
-          )
-        ],
-      ),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.data!.siteName != null)
+          tiamat.Text.labelLow(
+            widget.data!.siteName!,
+            maxLines: 1,
+            overflow: TextOverflow.fade,
+          ),
+        Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (widget.data!.title != null)
+              tiamat.Text.labelEmphasised(
+                widget.data!.title!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            if (widget.data!.description != null)
+              tiamat.Text.tiny(
+                widget.data!.description!,
+                maxLines: 2,
+                color: Theme.of(context).colorScheme.secondary,
+                overflow: TextOverflow.ellipsis,
+              )
+          ],
+        )
+      ],
     );
   }
 }

--- a/commet/lib/ui/molecules/video_player/video_player.dart
+++ b/commet/lib/ui/molecules/video_player/video_player.dart
@@ -20,12 +20,14 @@ class VideoPlayer extends StatefulWidget {
       super.key,
       this.canGoFullscreen = false,
       this.onFullscreen,
+      this.streamUrl,
       this.decodeFirstFrame = false,
       this.controller,
       this.doThumbnail = true,
       this.showProgressBar = true});
   final FileProvider videoFile;
   final ImageProvider? thumbnail;
+  final Uri? streamUrl;
   final bool showProgressBar;
   final bool canGoFullscreen;
   final bool doThumbnail;
@@ -327,6 +329,7 @@ class VideoPlayerState extends State<VideoPlayer> {
       controller: controller,
       videoFile: widget.videoFile,
       decodeFirstFrame: widget.decodeFirstFrame,
+      streamUrl: widget.streamUrl,
     );
   }
 }

--- a/commet/lib/ui/molecules/video_player/video_player_implementation.dart
+++ b/commet/lib/ui/molecules/video_player/video_player_implementation.dart
@@ -1,6 +1,8 @@
 import 'dart:typed_data';
 
 import 'package:commet/cache/file_provider.dart';
+import 'package:commet/main.dart';
+import 'package:commet/ui/navigation/adaptive_dialog.dart';
 import 'package:flutter/widgets.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
@@ -12,10 +14,12 @@ class VideoPlayerImplementation extends StatefulWidget {
       {required this.controller,
       required this.videoFile,
       this.decodeFirstFrame = false,
+      this.streamUrl,
       this.width = 640,
       this.height = 340,
       super.key});
   final FileProvider videoFile;
+  final Uri? streamUrl;
   final int width;
   final int height;
   final bool decodeFirstFrame;
@@ -58,23 +62,55 @@ class _VideoPlayerImplementationState extends State<VideoPlayerImplementation> {
 
     controller = VideoController(player);
 
-    Future.microtask(() async {
-      widget.controller.setBuffering(true);
-      var sub = widget.videoFile.onProgressChanged?.listen((data) {
-        widget.controller.setBufferingProgress(data);
+    if (widget.streamUrl == null) {
+      Future.microtask(() async {
+        widget.controller.setBuffering(true);
+        var sub = widget.videoFile.onProgressChanged?.listen((data) {
+          widget.controller.setBufferingProgress(data);
+        });
+        file = await widget.videoFile.resolve();
+
+        sub?.cancel();
+
+        await player.open(Playlist([Media(file.toString())]),
+            play: !widget.decodeFirstFrame);
+        widget.controller.setBuffering(false);
+
+        setState(() {
+          loaded = true;
+        });
       });
-      file = await widget.videoFile.resolve();
+    } else {
+      Future.microtask(() async {
+        widget.controller.setBuffering(true);
 
-      sub?.cancel();
+        var host = widget.streamUrl!.host;
 
-      await player.open(Playlist([Media(file.toString())]),
-          play: !widget.decodeFirstFrame);
-      widget.controller.setBuffering(false);
+        bool allowed = preferences.allowedRemoteVideoHosts.value.contains(host);
 
-      setState(() {
-        loaded = true;
+        if (!allowed) {
+          bool? confirmation = await AdaptiveDialog.confirmation(context,
+              dangerous: true,
+              title: "Stream Remote Video",
+              prompt:
+                  "Do you want to allow connections to `${widget.streamUrl!.host}` to stream this video?");
+
+          allowed = confirmation == true;
+          preferences.allowedRemoteVideoHosts.add(host);
+        }
+
+        if (allowed) {
+          await player.open(Playlist([Media(widget.streamUrl!.toString())]),
+              play: !widget.decodeFirstFrame);
+        }
+
+        widget.controller.setBuffering(false);
+
+        setState(() {
+          loaded = true;
+        });
       });
-    });
+    }
   }
 
   @override
@@ -87,7 +123,7 @@ class _VideoPlayerImplementationState extends State<VideoPlayerImplementation> {
   Widget build(BuildContext context) {
     if (loaded) {
       return Video(
-        fit: BoxFit.cover,
+        fit: BoxFit.contain,
         controller: controller!,
         controls: null,
       );

--- a/commet/lib/ui/pages/settings/categories/app/general_settings_page.dart
+++ b/commet/lib/ui/pages/settings/categories/app/general_settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:commet/config/layout_config.dart';
 import 'package:commet/main.dart';
 import 'package:commet/ui/pages/settings/categories/app/boolean_toggle.dart';
+import 'package:commet/ui/pages/settings/categories/app/string_list_preference_editor.dart';
 import 'package:commet/ui/pages/setup/menus/check_for_updates.dart';
 import 'package:commet/utils/update_checker.dart';
 import 'package:flutter/widgets.dart';
@@ -204,7 +205,14 @@ class GeneralSettingsPageState extends State<GeneralSettingsPage> {
                 description:
                     "When showing videos in fullscreen, automatically rotate the video to best fill the screen",
               ),
-            ]
+            ],
+            Seperator(),
+            StringListPreferenceEditor(
+              preference: preferences.allowedRemoteVideoHosts,
+              title: "Allowed Video Hosts",
+              description:
+                  "Allowed web hosts for displaying external videos, such as in URL Previews. Your IP address will be revealed to these servers when accessing the video",
+            )
           ]),
         ),
       ],

--- a/commet/lib/ui/pages/settings/categories/app/string_list_preference_editor.dart
+++ b/commet/lib/ui/pages/settings/categories/app/string_list_preference_editor.dart
@@ -1,0 +1,94 @@
+import 'package:commet/config/preferences/string_list_preference.dart';
+import 'package:commet/ui/navigation/adaptive_dialog.dart';
+import 'package:flutter/material.dart';
+
+import 'package:tiamat/tiamat.dart' as tiamat;
+
+class StringListPreferenceEditor extends StatefulWidget {
+  const StringListPreferenceEditor(
+      {required this.preference,
+      required this.title,
+      this.description,
+      super.key});
+  final StringListPreference preference;
+
+  final String title;
+  final String? description;
+
+  @override
+  State<StringListPreferenceEditor> createState() =>
+      _StringListPreferenceEditorState();
+}
+
+class _StringListPreferenceEditorState
+    extends State<StringListPreferenceEditor> {
+  late List<String> items;
+
+  @override
+  void initState() {
+    items = widget.preference.value;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        decoration: BoxDecoration(
+            color: ColorScheme.of(context).surfaceContainer.withAlpha(100),
+            border: BoxBorder.all(
+                color: ColorScheme.of(context).secondary.withAlpha(20)),
+            borderRadius: BorderRadius.circular(8)),
+        child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                tiamat.Text(widget.title),
+                if (widget.description != null)
+                  tiamat.Text.labelLow(widget.description!),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (items.isEmpty)
+                        SizedBox(
+                          height: 50,
+                          child:
+                              Center(child: tiamat.Text.labelLow("No Entries")),
+                        ),
+                      if (items.isNotEmpty)
+                        Column(
+                          spacing: 8,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: items
+                              .map((i) => Row(
+                                    spacing: 8,
+                                    children: [
+                                      tiamat.IconButton(
+                                        size: 18,
+                                        icon: Icons.delete,
+                                        onPressed: () async {
+                                          if (await AdaptiveDialog.confirmation(
+                                                  context) ==
+                                              true) {
+                                            widget.preference.remove(i);
+
+                                            setState(() {
+                                              items = widget.preference.value;
+                                            });
+                                          }
+                                        },
+                                      ),
+                                      tiamat.Text.labelLow(i),
+                                    ],
+                                  ))
+                              .toList(),
+                        ),
+                    ],
+                  ),
+                )
+              ],
+            )));
+  }
+}

--- a/commet/lib/utils/download_utils.dart
+++ b/commet/lib/utils/download_utils.dart
@@ -122,7 +122,9 @@ class DownloadUtils {
 
     if (attachment is FileAttachment) {
       file = attachment.file;
-      name = attachment.name;
+      if (attachment.name != null) {
+        name = attachment.name!;
+      }
     } else {
       return;
     }

--- a/commet/lib/utils/mime.dart
+++ b/commet/lib/utils/mime.dart
@@ -44,6 +44,8 @@ class Mime {
     "video/quicktime"
   };
 
+  static const videoStreamTypes = {"application/vnd.apple.mpegurl"};
+
   static const archiveTypes = {
     "application/x-7z-compressed",
     "application/x-bzip",


### PR DESCRIPTION
Closes #604
Closes #797 

Tweaks the URL Preview UI to show larger images, and changes the behaviour so tapping the image will open it in the lightbox, just like image attachments.

Also adds the ability to embed videos, which are unfortunately not loaded via the homeserver, and must instead make a direct connection to the URL host. Commet will ask the user for permission before connecting to a host, to avoid the possibility of automatic IP grabbers. 

Maybe it would be a good idea to hard code some known common sources which are likely to be safe