### PR TITLE
update build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This repo currently has a monorepo structure, containing two flutter projects: C
 ### 2. Install Libraries
 Commet requires some additional libraries to be built 
 ```bash
-sudo apt-get install -y ninja-build libgtk-3-dev libmpv-dev mpv ffmpeg libmimalloc-dev
+sudo apt-get install -y cmake clang ninja-build rustup libgtk-3-dev libmpv-dev mpv ffmpeg libmimalloc-dev libwebkit2gtk-4.1-dev keybinder-3.0
 ```
 
 ### 3. Fetch Dependencies


### PR DESCRIPTION
I build commet within a distrobox environment, within an ubuntu 24.04 image. Compared to the instructions on main, a few dependencies were missing, namely: `cmake` `clang` `rustup` `libwebkit2gtk-4.1-dev` and `keybinder-3.0`