### PR TITLE
Disable building Rust lib on Android

### DIFF
--- a/commet/lib/main.dart
+++ b/commet/lib/main.dart
@@ -16,7 +16,6 @@ import 'package:commet/debug/l10n_debug_lookup.dart';
 import 'package:commet/debug/log.dart';
 import 'package:commet/diagnostic/diagnostics.dart';
 import 'package:commet/generated/intl/messages_all.dart';
-import 'package:commet/rust/api/simple.dart';
 import 'package:commet/rust/frb_generated.dart';
 import 'package:commet/single_instance.dart';
 import 'package:commet/ui/organisms/overlay_windows/overlay_window_manager.dart';

--- a/commet/lib/main.dart
+++ b/commet/lib/main.dart
@@ -207,10 +207,9 @@ Future<void> initNecessary() async {
   await preferences.init();
   await initDatabaseServer();
 
-  if(PlatformUtils.isWindows || PlatformUtils.isLinux) {
+  if (PlatformUtils.isWindows || PlatformUtils.isLinux) {
     await RustLib.init();
   }
-
 
   fileCache = FileCache.getFileCacheInstance();
 

--- a/commet/lib/main.dart
+++ b/commet/lib/main.dart
@@ -207,9 +207,10 @@ Future<void> initNecessary() async {
   await preferences.init();
   await initDatabaseServer();
 
-  await RustLib.init();
+  if(PlatformUtils.isWindows || PlatformUtils.isLinux) {
+    await RustLib.init();
+  }
 
-  Log.i(greet(name: "test"));
 
   fileCache = FileCache.getFileCacheInstance();
 

--- a/rust/rust_builder/android/build.gradle
+++ b/rust/rust_builder/android/build.gradle
@@ -49,8 +49,8 @@ android {
     }
 }
 
-apply from: "../cargokit/gradle/plugin.gradle"
-cargokit {
-    manifestDir = "../../rust"
-    libname = "rust_lib_commet"
-}
+// apply from: "../cargokit/gradle/plugin.gradle"
+// cargokit {
+//     manifestDir = "../../rust"
+//     libname = "rust_lib_commet"
+// }


### PR DESCRIPTION
Currently the rust library is only used on Linux and Windows, so no point in building it