### PR TITLE
Fix Quick Switcher RangeError

### DIFF
--- a/commet/lib/ui/navigation/quick_switcher.dart
+++ b/commet/lib/ui/navigation/quick_switcher.dart
@@ -184,7 +184,7 @@ class _QuickSwitcherState extends State<QuickSwitcher> {
                 for (var room in clientManager!.rooms
                     .sorted((a, b) =>
                         b.lastEventTimestamp.compareTo(a.lastEventTimestamp))
-                    .sublist(0, 4))
+                    .sublist(0, clientManager!.rooms.length.clamp(0, 4)))
                   RoomPanelView(
                     onTap: () {
                       EventBus.doOpenRoom(room.identifier,


### PR DESCRIPTION
This fixes a bug with the quick switcher.
When opening the quick switcher, it is supposed to list the 4 most recent rooms. However, if you are a member <4 rooms, it would throw a RangeError and display a giant empty square without an error message to the user.