### PR TITLE
Reset Interaction Event when replying with a Sticker/GIF

### DIFF
--- a/commet/lib/ui/organisms/chat/chat.dart
+++ b/commet/lib/ui/organisms/chat/chat.dart
@@ -331,6 +331,10 @@ class ChatState extends State<Chat> {
         interactionType == EventInteractionType.reply
             ? interactingEvent
             : null);
+
+    if (interactionType == EventInteractionType.reply) {
+      setInteractingEvent(null);
+    }
   }
 
   Future<void> sendGif(GifSearchResult gif) async {
@@ -340,6 +344,10 @@ class ChatState extends State<Chat> {
         interactionType == EventInteractionType.reply
             ? interactingEvent
             : null);
+
+    if (interactionType == EventInteractionType.reply) {
+      setInteractingEvent(null);
+    }
   }
 
   void editLastMessage() {


### PR DESCRIPTION
Without this patch, if you send a Sticker of GIF while replying to something, the Interaction Event will remain unchanged, like this:

<img width="258" height="303" alt="1" src="https://github.com/user-attachments/assets/22015e4c-3105-41d1-a0ce-09d272cd28a9" />

With this patch, it resets the Interaction Event, so you don't reply to the same thing twice:

<img width="258" height="303" alt="2" src="https://github.com/user-attachments/assets/cb4309e1-1200-45e7-a9da-b500c832c851" />

It will only do so for Replies.

<img width="258" height="303" alt="3" src="https://github.com/user-attachments/assets/6f413464-16de-4154-af9c-d1cb6bbabd0e" />

I don't know if it's intended behavior, but I thought it was weird.