### PR TITLE
Zoomable Avatars

### DIFF
--- a/commet/lib/ui/atoms/room_header.dart
+++ b/commet/lib/ui/atoms/room_header.dart
@@ -4,6 +4,7 @@ import 'package:commet/client/components/direct_messages/direct_message_componen
 import 'package:commet/client/components/user_presence/user_presence_component.dart';
 import 'package:commet/config/layout_config.dart';
 import 'package:commet/main.dart'; // For preferences
+import 'package:commet/ui/atoms/lightbox.dart';
 import 'package:commet/ui/molecules/user_panel.dart';
 import 'package:commet/utils/notification_utils.dart';
 import 'package:flutter/cupertino.dart';
@@ -109,22 +110,26 @@ class _RoomHeaderState extends State<RoomHeader> {
       );
     } else {
       iconPadding = EdgeInsets.fromLTRB(4, 0, 8, 0);
-      iconWidget = tiamat.Avatar(
-        radius: 15,
-        image: showRoomIcons && widget.room.avatar != null
-            ? widget.room.avatar
-            : null,
-        placeholderText:
-            (showRoomIcons && useGenericIcons && widget.room.avatar == null) ||
+      iconWidget = GestureDetector(
+          onTap: fullscreenAvatar,
+          child: tiamat.Avatar(
+            radius: 15,
+            image: showRoomIcons && widget.room.avatar != null
+                ? widget.room.avatar
+                : null,
+            placeholderText: (showRoomIcons &&
+                        useGenericIcons &&
+                        widget.room.avatar == null) ||
                     (!showRoomIcons && useGenericIcons)
                 ? widget.room.displayName
                 : "",
-        placeholderColor:
-            (showRoomIcons && useGenericIcons && widget.room.avatar == null) ||
+            placeholderColor: (showRoomIcons &&
+                        useGenericIcons &&
+                        widget.room.avatar == null) ||
                     (!showRoomIcons && useGenericIcons)
                 ? widget.room.defaultColor
                 : m.Colors.grey,
-      );
+          ));
     }
     return HeaderView(
         showBurger: MediaQuery.of(context).mobile,
@@ -136,6 +141,10 @@ class _RoomHeaderState extends State<RoomHeader> {
         onBurgerMenuTap: widget.onBurgerMenuTap,
         menu: widget.menu,
         status: status);
+  }
+
+  void fullscreenAvatar() {
+    Lightbox.show(context, image: widget.room.avatar);
   }
 }
 

--- a/commet/lib/ui/organisms/space_summary/space_summary_view.dart
+++ b/commet/lib/ui/organisms/space_summary/space_summary_view.dart
@@ -8,6 +8,7 @@ import 'package:commet/client/room_preview.dart';
 import 'package:commet/client/space_child.dart';
 import 'package:commet/config/build_config.dart';
 import 'package:commet/config/layout_config.dart';
+import 'package:commet/ui/atoms/lightbox.dart';
 import 'package:commet/ui/atoms/room_panel.dart';
 import 'package:commet/ui/atoms/room_panel_view.dart';
 import 'package:commet/ui/atoms/scaled_safe_area.dart';
@@ -353,20 +354,26 @@ class SpaceSummaryViewState extends State<SpaceSummaryView> {
           child: Padding(
               padding: const EdgeInsets.fromLTRB(0, 150, 0, 0),
               child: ScaledSafeArea(
-                child: Avatar.extraLarge(
-                  border: BoxBorder.all(
-                      color: Theme.of(context).colorScheme.surface,
-                      width: 10,
-                      style: BorderStyle.solid,
-                      strokeAlign: 0.5),
-                  image: widget.avatar,
-                  placeholderText: widget.displayName,
-                  placeholderColor: widget.spaceColor,
-                ),
+                child: GestureDetector(
+                    onTap: fullscreenAvatar,
+                    child: Avatar.extraLarge(
+                      border: BoxBorder.all(
+                          color: Theme.of(context).colorScheme.surface,
+                          width: 10,
+                          style: BorderStyle.solid,
+                          strokeAlign: 0.5),
+                      image: widget.avatar,
+                      placeholderText: widget.displayName,
+                      placeholderColor: widget.spaceColor,
+                    )),
               )),
         ),
       ],
     );
+  }
+
+  void fullscreenAvatar() {
+    Lightbox.show(context, image: widget.avatar);
   }
 
   Widget buildPreviewList() {

--- a/commet/lib/ui/organisms/user_profile/user_profile_view.dart
+++ b/commet/lib/ui/organisms/user_profile/user_profile_view.dart
@@ -7,6 +7,7 @@ import 'package:commet/config/layout_config.dart';
 import 'package:commet/config/platform_utils.dart';
 import 'package:commet/main.dart';
 import 'package:commet/ui/atoms/adaptive_context_menu.dart';
+import 'package:commet/ui/atoms/lightbox.dart';
 import 'package:commet/ui/atoms/scaled_safe_area.dart';
 import 'package:commet/ui/atoms/tiny_pill.dart';
 import 'package:commet/ui/navigation/adaptive_dialog.dart';
@@ -382,7 +383,7 @@ class UserProfileViewState extends State<UserProfileView> {
                                     child: GestureDetector(
                                         onTap: widget.isSelf
                                             ? widget.onSetAvatar
-                                            : null,
+                                            : fullscreenAvatar,
                                         child: tiamat.Avatar.large(
                                           border: BoxBorder.all(
                                               color: background,
@@ -409,6 +410,10 @@ class UserProfileViewState extends State<UserProfileView> {
         ),
       ),
     );
+  }
+
+  void fullscreenAvatar() {
+    Lightbox.show(context, image: widget.userAvatar!);
   }
 
   Padding username(BuildContext context) {


### PR DESCRIPTION
This adds the Lightbox functionality to User Profiles, Room Headers and Space Summaries and closes #537.

One issue I have encountered with this is that if you open a *DM* with someone and zoom into the *Room's* Avatar, you can see that it's heavily compressed.

I think it might also be nice to have download button appear upon long-pressing the Lightbox (with regular images aswell!) just like you have with the images in image gallery channels?