### PR TITLE
Add Notification Diagnostics

### DIFF
--- a/commet/lib/client/components/push_notification/android/android_notifier.dart
+++ b/commet/lib/client/components/push_notification/android/android_notifier.dart
@@ -120,12 +120,14 @@ class AndroidNotifier implements Notifier {
     }
   }
 
-  Future<void> checkPermission() async {
+  Future<bool> checkPermission() async {
     var android = flutterLocalNotificationsPlugin!
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>()!;
 
     hasPermission = await android.requestNotificationsPermission() ?? false;
+
+    return hasPermission;
   }
 
   @override

--- a/commet/lib/client/components/push_notification/android/android_notifier.dart
+++ b/commet/lib/client/components/push_notification/android/android_notifier.dart
@@ -70,7 +70,16 @@ class AndroidNotifier implements Notifier {
     }
 
     if (localClientId == null) {
+      var cache = preferences.getRoomsListCache();
+      var id =
+          cache.entries.firstWhereOrNull((i) => i.value.contains(roomId))?.key;
+      Log.i("Found client id from rooms list cache: $id");
+      localClientId = id;
+    }
+
+    if (localClientId == null) {
       Log.w("Received notification did not contain a client id!");
+
       return;
     }
 

--- a/commet/lib/client/components/push_notification/android/firebase_push_notifier.dart
+++ b/commet/lib/client/components/push_notification/android/firebase_push_notifier.dart
@@ -12,6 +12,7 @@ import 'package:commet/client/room.dart';
 import 'package:commet/debug/log.dart';
 import 'package:commet/main.dart';
 import 'package:commet/service/background_service_notifications/background_service_task_notification2.dart';
+import 'package:commet/utils/event_bus.dart';
 
 // Manage these to enable / disable firebase
 // import 'package:firebase_core/firebase_core.dart';
@@ -23,6 +24,8 @@ dynamic DefaultFirebaseOptions;
 // --------
 
 Future<void> onForegroundMessage(dynamic message) async {
+  EventBus.onReceivedPushNotificationData.add("${message.data}");
+
   return AndroidNotifier.onForegroundMessage(message.data);
 }
 
@@ -31,6 +34,8 @@ Future<void> _firebaseMessagingBackgroundHandler(dynamic message) async {
   Log.prefix = "fcm-background";
   Log.i("Got background message: ${message.data}");
   isHeadless = true;
+
+  EventBus.onReceivedPushNotificationData.add("${message.data}");
 
   final data = message.data;
 

--- a/commet/lib/client/components/push_notification/android/firebase_push_notifier.dart
+++ b/commet/lib/client/components/push_notification/android/firebase_push_notifier.dart
@@ -10,9 +10,9 @@ import 'package:commet/client/components/push_notification/notification_manager.
 import 'package:commet/client/components/push_notification/notifier.dart';
 import 'package:commet/client/room.dart';
 import 'package:commet/debug/log.dart';
+import 'package:commet/utils/event_bus.dart';
 import 'package:commet/main.dart';
 import 'package:commet/service/background_service_notifications/background_service_task_notification2.dart';
-import 'package:commet/utils/event_bus.dart';
 
 // Manage these to enable / disable firebase
 // import 'package:firebase_core/firebase_core.dart';

--- a/commet/lib/client/components/push_notification/android/unified_push_notifier.dart
+++ b/commet/lib/client/components/push_notification/android/unified_push_notifier.dart
@@ -13,6 +13,7 @@ import 'package:commet/debug/log.dart';
 import 'package:commet/main.dart';
 import 'package:commet/service/background_service_notifications/background_service_task_notification2.dart';
 import 'package:commet/ui/pages/setup/menus/unified_push_setup.dart';
+import 'package:commet/utils/event_bus.dart';
 import 'package:commet/utils/first_time_setup.dart';
 import 'package:flutter/material.dart';
 import 'package:unifiedpush/unifiedpush.dart';
@@ -122,6 +123,9 @@ class UnifiedPushNotifier implements Notifier {
   void onMessage(Uint8List message, String instance) async {
     Log.i("Received unified push message! $instance");
     var data = utf8.decode(message);
+
+    EventBus.onReceivedPushNotificationData.add(data);
+
     var json = jsonDecode(data) as Map<String, dynamic>;
 
     var notifData = json['notification'] as Map<String, dynamic>;

--- a/commet/lib/client/components/push_notification/modifiers/do_not_disturb.dart
+++ b/commet/lib/client/components/push_notification/modifiers/do_not_disturb.dart
@@ -3,7 +3,8 @@ import 'package:commet/client/components/push_notification/notification_content.
 
 class NotificationModifierDoNotDisturb implements NotificationModifier {
   @override
-  Future<NotificationContent?> process(NotificationContent content) async {
+  Future<NotificationContent?> process(NotificationContent content,
+      {Function(String reason)? onNotificationRejected}) async {
     return null;
   }
 }

--- a/commet/lib/client/components/push_notification/modifiers/hide_content.dart
+++ b/commet/lib/client/components/push_notification/modifiers/hide_content.dart
@@ -10,7 +10,8 @@ class NotificationModifierHideContent implements NotificationModifier {
           "Placeholder text to put in a notification when the user has privacy enhanced notifications enabled.");
 
   @override
-  Future<NotificationContent?> process(NotificationContent content) async {
+  Future<NotificationContent?> process(NotificationContent content,
+      {Function(String reason)? onNotificationRejected}) async {
     content.content = "A Notification was received";
 
     if (content is MessageNotificationContent) {

--- a/commet/lib/client/components/push_notification/modifiers/linux_notification_formatting.dart
+++ b/commet/lib/client/components/push_notification/modifiers/linux_notification_formatting.dart
@@ -26,7 +26,8 @@ class NotificationModifierLinuxFormatting implements NotificationModifier {
   final double thumbnailImageSize = 100;
 
   @override
-  Future<NotificationContent?> process(NotificationContent content) async {
+  Future<NotificationContent?> process(NotificationContent content,
+      {Function(String reason)? onNotificationRejected}) async {
     if (preferences.formatNotificationBody.value == false) {
       return content;
     }

--- a/commet/lib/client/components/push_notification/modifiers/notification_modifiers.dart
+++ b/commet/lib/client/components/push_notification/modifiers/notification_modifiers.dart
@@ -1,5 +1,6 @@
 import 'package:commet/client/components/push_notification/notification_content.dart';
 
 abstract class NotificationModifier {
-  Future<NotificationContent?> process(NotificationContent content);
+  Future<NotificationContent?> process(NotificationContent content,
+      {Function(String reason)? onNotificationRejected});
 }

--- a/commet/lib/client/components/push_notification/modifiers/suppress_active_room.dart
+++ b/commet/lib/client/components/push_notification/modifiers/suppress_active_room.dart
@@ -17,7 +17,8 @@ class NotificationModifierSuppressActiveRoom implements NotificationModifier {
   }
 
   @override
-  Future<NotificationContent?> process(NotificationContent content) async {
+  Future<NotificationContent?> process(NotificationContent content,
+      {Function(String reason)? onNotificationRejected}) async {
     if (preferences.suppressNotificationWhenRoomFocused.value == false) {
       return content;
     }
@@ -34,7 +35,11 @@ class NotificationModifierSuppressActiveRoom implements NotificationModifier {
         }
       }
 
-      if (content.roomId == roomId) return null;
+      if (content.roomId == roomId) {
+        onNotificationRejected?.call(
+            "The notification was intended for the same room that is currently open, and the app was detected as being in focus. If this doesn't seem right, you may want to disable the 'Hide notifications for current room' setting to bypass this check");
+        return null;
+      }
     }
 
     return content;

--- a/commet/lib/client/components/push_notification/modifiers/suppress_other_device_active.dart
+++ b/commet/lib/client/components/push_notification/modifiers/suppress_other_device_active.dart
@@ -10,7 +10,8 @@ import 'package:matrix/matrix_api_lite/generated/model.dart' show Device;
 class NotificationModifierSuppressOtherActiveDevice
     implements NotificationModifier {
   @override
-  Future<NotificationContent?> process(NotificationContent content) async {
+  Future<NotificationContent?> process(NotificationContent content,
+      {Function(String reason)? onNotificationRejected}) async {
     if (!preferences.silenceNotifications.value) {
       return content;
     }

--- a/commet/lib/client/components/push_notification/notification_manager.dart
+++ b/commet/lib/client/components/push_notification/notification_manager.dart
@@ -92,9 +92,11 @@ class NotificationManager {
   }
 
   static Future<void> notify(NotificationContent notification,
-      {bool forceShow = false}) async {
+      {bool forceShow = false,
+      Function(String reason)? onNotificationRejected}) async {
     if (_notifier == null) {
       Log.e("Failed to show notification, notifier has not been initialzied");
+      onNotificationRejected?.call("Notifier has not been initialized");
       return;
     }
 
@@ -111,9 +113,13 @@ class NotificationManager {
         if (modifier is NotificationModifierSuppressOtherActiveDevice) continue;
       }
 
-      content = await modifier.process(content!);
+      content = await modifier.process(content!,
+          onNotificationRejected: onNotificationRejected);
       if (content == null) {
         Log.d("Modifier returned null notification, returning");
+
+        onNotificationRejected?.call(
+            "Notification modifier '${modifier}' rejected the notification");
         return;
       }
     }

--- a/commet/lib/client/matrix/database/matrix_database_io.dart
+++ b/commet/lib/client/matrix/database/matrix_database_io.dart
@@ -46,7 +46,9 @@ NativeDatabase setupNativeDatabase(File file, {bool readOnly = false}) {
   return NativeDatabase.opened(
     db,
     setup: (database) {
-      database.execute("pragma journal_mode = wal;");
+      if (!readOnly) {
+        database.execute("pragma journal_mode = wal;");
+      }
     },
   );
 }

--- a/commet/lib/client/matrix/matrix_room.dart
+++ b/commet/lib/client/matrix/matrix_room.dart
@@ -316,8 +316,9 @@ class MatrixRoom extends Room {
     handleNotification(event);
   }
 
-  Future<void> handleNotification(TimelineEvent event) async {
-    if (!shouldNotify(event)) {
+  Future<void> handleNotification(TimelineEvent event,
+      {Function(String reason)? onNotificationRejected}) async {
+    if (!shouldNotify(event, onNotificationRejected: onNotificationRejected)) {
       return;
     }
 
@@ -335,13 +336,15 @@ class MatrixRoom extends Room {
       var notification =
           await MessageNotificationContent.fromEvent(event, this);
       if (notification != null) {
-        NotificationManager.notify(notification);
+        NotificationManager.notify(notification,
+            onNotificationRejected: onNotificationRejected);
       }
     }
   }
 
   @override
-  bool shouldNotify(TimelineEvent event) {
+  bool shouldNotify(TimelineEvent event,
+      {Function(String reason)? onNotificationRejected}) {
     if ((client as MatrixClient).firstSyncComplete == false) {
       return false;
     }
@@ -350,6 +353,8 @@ class MatrixRoom extends Room {
     if (clientManager?.clients
             .any((element) => element.self?.identifier == event.senderId) ==
         true) {
+      onNotificationRejected
+          ?.call("Message came from a user logged in to this client");
       return false;
     }
 
@@ -357,11 +362,16 @@ class MatrixRoom extends Room {
 
     // dont notify if we are receiving an old message
     if (timeDiff.inMinutes > 10) {
+      onNotificationRejected?.call("Message is over 10 minutes old");
       return false;
     }
 
     var evaluator = _matrixRoom.client.pushruleEvaluator;
     var match = evaluator.match((event as MatrixTimelineEvent).event);
+
+    if (match.notify == false) {
+      onNotificationRejected?.call("Did not pass push rules");
+    }
 
     return match.notify;
   }

--- a/commet/lib/client/matrix/matrix_room.dart
+++ b/commet/lib/client/matrix/matrix_room.dart
@@ -319,17 +319,21 @@ class MatrixRoom extends Room {
   Future<void> handleNotification(TimelineEvent event,
       {Function(String reason)? onNotificationRejected}) async {
     if (!shouldNotify(event, onNotificationRejected: onNotificationRejected)) {
+      onNotificationRejected?.call("shouldNotify returned false");
       return;
     }
 
     if (event is MatrixTimelineEventCall ||
         event is MatrixTimelineEventUnknown) {
+      onNotificationRejected?.call("Event type does not trigger notifications");
       return;
     }
 
     if (event is TimelineEventMessage || event is TimelineEventSticker) {
       // let push notifications handle it
       if (BuildConfig.ANDROID) {
+        onNotificationRejected?.call(
+            "Notifications should be handled by a push service on Android, but we are in the desktop notifications handler");
         return;
       }
 
@@ -338,6 +342,8 @@ class MatrixRoom extends Room {
       if (notification != null) {
         NotificationManager.notify(notification,
             onNotificationRejected: onNotificationRejected);
+      } else {
+        onNotificationRejected?.call("Notification content was null");
       }
     }
   }

--- a/commet/lib/config/preferences.dart
+++ b/commet/lib/config/preferences.dart
@@ -12,6 +12,7 @@ import 'package:commet/config/theme_config.dart';
 import 'package:commet/main.dart';
 import 'package:flutter/material.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
+import 'package:matrix/matrix.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tiamat/config/style/theme_amoled.dart';
 import 'package:tiamat/config/style/theme_json_converter.dart';
@@ -341,6 +342,24 @@ class Preferences {
         ?.remove(_rejectedCapabilitiesKey(clientId, widgetNamespace));
 
     await _preferences?.remove(_widgetAllowedKey(clientId, widgetNamespace));
+  }
+
+  static const String _roomsListCache = "rooms_list_cache";
+
+  Map<String, List<String>> getRoomsListCache() {
+    var str = _preferences?.getString(_roomsListCache) ?? "{}";
+    var data = jsonDecode(str) as Map<String, dynamic>;
+
+    var result = Map<String, List<String>>.new();
+    for (var entry in data.entries) {
+      result[entry.key] = data.tryGetList<String>(entry.key) ?? [];
+    }
+
+    return result;
+  }
+
+  Future<void> storeRoomsListCache(Map<String, List<String>> rooms) async {
+    await _preferences?.setString(_roomsListCache, jsonEncode(rooms));
   }
 
   BoolPreference shouldFollowSystemTheme =

--- a/commet/lib/main.dart
+++ b/commet/lib/main.dart
@@ -291,6 +291,16 @@ Future<void> startGui() async {
     FirstTimeSetup.registerPostLoginSetup(UpdateCheckerSetup());
   }
 
+  if (PlatformUtils.isAndroid) {
+    var roomsListCache = Map<String, List<String>>.new();
+    for (var client in clientManager!.clients) {
+      roomsListCache[client.identifier] =
+          client.rooms.map((i) => i.identifier).toList();
+    }
+
+    preferences.storeRoomsListCache(roomsListCache);
+  }
+
   runApp(App(
     clientManager: clientManager!,
     initialTheme: initialTheme,

--- a/commet/lib/service/background_service_notifications/background_service_task_notification2.dart
+++ b/commet/lib/service/background_service_notifications/background_service_task_notification2.dart
@@ -106,6 +106,15 @@ class BackgroundNotificationsManager2 {
 
       var localClientId = data["local_client_id"] as String?;
 
+      if (localClientId == null) {
+        var cache = preferences.getRoomsListCache();
+        var id = cache.entries
+            .firstWhereOrNull((i) => i.value.contains(roomId))
+            ?.key;
+        Log.i("Found client id from rooms list cache: $id");
+        localClientId = id;
+      }
+
       if (roomId == null || eventId == null) {
         Log.w("TODO: Handle counts: $counts");
         return;

--- a/commet/lib/ui/molecules/notification_debugger.dart
+++ b/commet/lib/ui/molecules/notification_debugger.dart
@@ -1,0 +1,360 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:commet/client/client.dart';
+import 'package:commet/client/components/push_notification/android/android_notifier.dart';
+import 'package:commet/client/components/push_notification/android/firebase_push_notifier.dart';
+import 'package:commet/client/components/push_notification/android/unified_push_notifier.dart';
+import 'package:commet/client/components/push_notification/notification_manager.dart';
+import 'package:commet/client/matrix/matrix_client.dart';
+import 'package:commet/client/matrix/matrix_room.dart';
+import 'package:commet/client/matrix/timeline_events/matrix_timeline_event.dart';
+import 'package:commet/client/timeline_events/timeline_event.dart';
+import 'package:commet/config/build_config.dart';
+import 'package:commet/config/platform_utils.dart';
+import 'package:commet/debug/log.dart';
+import 'package:commet/main.dart';
+import 'package:commet/ui/atoms/notifying_list_builder.dart';
+import 'package:commet/utils/event_bus.dart';
+import 'package:commet/utils/notifying_list.dart';
+import 'package:commet/utils/stream_utils.dart';
+import 'package:flutter/material.dart';
+
+import 'package:tiamat/tiamat.dart' as tiamat;
+import 'package:unifiedpush/unifiedpush.dart';
+import 'package:window_manager/window_manager.dart';
+
+import 'package:http/http.dart' as http;
+
+class NotificationDebugger extends StatefulWidget {
+  const NotificationDebugger(
+      {this.event, this.room, required this.client, super.key});
+  final TimelineEvent? event;
+  final Client client;
+  final Room? room;
+  @override
+  State<NotificationDebugger> createState() => _NotificationDebuggerState();
+}
+
+class _NotificationDebugStep {
+  String name;
+  String description;
+  bool? passed;
+
+  _NotificationDebugStep(
+      {required this.name, required this.description, required this.passed});
+}
+
+class _NotificationDebuggerState extends State<NotificationDebugger> {
+  NotifyingList<_NotificationDebugStep> steps =
+      NotifyingList.empty(growable: true);
+  bool running = true;
+
+  @override
+  void initState() {
+    runTests();
+    super.initState();
+  }
+
+  bool get usesDesktopNotification =>
+      PlatformUtils.isLinux || PlatformUtils.isWindows;
+
+  Future<void> runTests() async {
+    if (usesDesktopNotification) {
+      await Future.delayed(Duration(seconds: 5));
+      await windowManager.minimize();
+    }
+
+    if (PlatformUtils.isAndroid) {
+      EventBus.openHomeScreen.add(null);
+    }
+
+    await Future.delayed(Duration(seconds: 1));
+
+    try {
+      if (widget.event case MatrixTimelineEvent event) {
+        if (usesDesktopNotification) {
+          await shouldNotifyTest(event);
+          await handleNotificationTest(event);
+        } else {
+          await checkPermissions();
+          await pushRulesTest(event, widget.room as MatrixRoom);
+          await checkPushGateway(event, widget.room as MatrixRoom);
+        }
+      }
+    } catch (e) {
+      steps.add(_NotificationDebugStep(
+          name: "Tests failed",
+          description: "An error occured while running tests: ${e}",
+          passed: false));
+    }
+    setState(() {
+      running = false;
+    });
+  }
+
+  Future<void> pushRulesTest(MatrixTimelineEvent event, MatrixRoom room) async {
+    var evaluator = room.matrixRoom.client.pushruleEvaluator;
+    var match = evaluator.match(event.event);
+
+    steps.add(_NotificationDebugStep(
+        name: "Push Rules",
+        description:
+            "Check if the event matches your account's defined push rules",
+        passed: match.notify));
+  }
+
+  Future<void> checkPermissions() async {
+    final notifier = NotificationManager.notifier;
+    var permission = false;
+
+    if (notifier is UnifiedPushNotifier) {
+      permission = await notifier.notifier.checkPermission();
+    } else if (notifier is FirebasePushNotifier) {
+      permission = await notifier.notifier.checkPermission();
+    } else if (notifier is AndroidNotifier) {
+      permission = await notifier.checkPermission();
+    }
+
+    var step = _NotificationDebugStep(
+        name: "Check permissions",
+        description:
+            "Tests if we have permission from the system to display a notification",
+        passed: permission);
+
+    steps.add(step);
+  }
+
+  Future<void> shouldNotifyTest(MatrixTimelineEvent event) async {
+    final shouldNotify = (widget.room as MatrixRoom).shouldNotify(
+      event,
+      onNotificationRejected: (reason) {
+        var step = _NotificationDebugStep(
+            name: "Notification rejected",
+            description: "$reason",
+            passed: false);
+
+        steps.add(step);
+      },
+    );
+
+    var step = _NotificationDebugStep(
+        name: "Should Notify",
+        description:
+            "Tests whether the given event should trigger a notification",
+        passed: shouldNotify);
+
+    steps.add(step);
+  }
+
+  Future<void> checkPushGateway(
+      MatrixTimelineEvent event, MatrixRoom room) async {
+    var matrixClient = (widget.client as MatrixClient).getMatrixClient();
+    var pushers = await matrixClient.getPushers();
+
+    if (BuildConfig.ENABLE_GOOGLE_SERVICES == false) {
+      steps.add(_NotificationDebugStep(
+          name: "Unified Push Configuration",
+          description: "Checks the current config for unified push",
+          passed: preferences.unifiedPushEnabled.value == true &&
+              preferences.unifiedPushEndpoint.value != null));
+
+      if (preferences.unifiedPushEnabled.value == true) {
+        var distributor = await UnifiedPush.getDistributor();
+
+        steps.add(_NotificationDebugStep(
+            name: "Unified Push Distributor",
+            description: "distributor for unified push: $distributor",
+            passed: distributor != null));
+      }
+    }
+
+    String? pushKey = BuildConfig.ENABLE_GOOGLE_SERVICES
+        ? preferences.fcmKey.value
+        : preferences.unifiedPushEndpoint.value;
+
+    var pusher = pushers
+        ?.where((i) =>
+            i.deviceDisplayName == matrixClient.clientName &&
+            i.pushkey == pushKey)
+        .firstOrNull;
+
+    var step = _NotificationDebugStep(
+        name: "Has Registered Pusher",
+        description:
+            "Tests if the client has registered a push notification service with the homeserver",
+        passed: pusher != null);
+
+    steps.add(step);
+
+    if (pusher != null) {
+      if (BuildConfig.ENABLE_GOOGLE_SERVICES &&
+          pusher.data.additionalProperties["type"] == "fcm") {
+        steps.add(_NotificationDebugStep(
+            name: "Pusher configuration",
+            description:
+                "Checks the pusher is configured to use Google services",
+            passed: true));
+      }
+
+      final url = pusher.data.url!.replace(path: "/_matrix/push/v1/notify");
+
+      final content = {
+        "notification": {
+          "devices": [
+            {
+              "app_id": pusher.appId,
+              "data": {
+                ...pusher.data.additionalProperties,
+              },
+              "pushkey": pusher.pushkey,
+            },
+          ],
+          "event_id": event.eventId,
+          "prio": "high",
+          "room_id": room.identifier
+        }
+      };
+
+      Log.i("Sending to: $url");
+      Log.i(
+        "Sending test notification: ${content}",
+      );
+
+      var startTime = DateTime.now();
+
+      var nextData =
+          EventBus.onReceivedPushNotificationData.stream.nextItemAsFuture();
+
+      var result = await http.post(url, body: jsonEncode(content), headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+      });
+
+      var step = _NotificationDebugStep(
+          name: "Send test notification",
+          description:
+              "Tests if sending a notification to the registered pusher is accepted",
+          passed: result.statusCode == 200);
+
+      steps.add(step);
+      try {
+        final result = await nextData.timeout(Duration(seconds: 20));
+        var endTime = DateTime.now();
+        var length = endTime.difference(startTime);
+        var step = _NotificationDebugStep(
+            name: "Receive notification",
+            description:
+                "Received data back from push service in ${length.inMilliseconds}ms: $result",
+            passed: true);
+
+        steps.add(step);
+      } catch (e) {
+        if (e is TimeoutException) {
+          var step = _NotificationDebugStep(
+              name: "Receive notification",
+              description:
+                  "Did not receive any data back from push service after waiting 20 seconds",
+              passed: false);
+
+          steps.add(step);
+        } else {
+          var step = _NotificationDebugStep(
+              name: "Receive notification",
+              description:
+                  "Unknown error occured waiting for notification data: $e",
+              passed: false);
+
+          steps.add(step);
+        }
+      }
+    }
+  }
+
+  Future<void> handleNotificationTest(MatrixTimelineEvent event) async {
+    final f = (widget.room as MatrixRoom).handleNotification(
+      event,
+      onNotificationRejected: (reason) {
+        var step = _NotificationDebugStep(
+            name: "Notification rejected",
+            description: "$reason",
+            passed: false);
+
+        steps.add(step);
+      },
+    );
+
+    await f;
+
+    var step = _NotificationDebugStep(
+        name: "Handle Notification",
+        description: "If you saw a notification, this test passed.",
+        passed: null);
+
+    steps.add(step);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 500,
+      height: 500,
+      child: Column(
+        children: [
+          if (running)
+            Column(
+              children: [
+                if (usesDesktopNotification)
+                  tiamat.Text.labelLow(
+                      "The app may be minimized while testing. if minimized, wait for atleast 5 seconds before re-opening"),
+                CircularProgressIndicator(),
+              ],
+            ),
+          if (!running)
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: tiamat.Text.label("Test complete"),
+            ),
+          Flexible(
+            child: NotifyingListBuilder(
+              list: steps,
+              itemBuilder: (context, value) {
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Row(
+                    spacing: 8,
+                    children: [
+                      Icon(
+                        value.passed == null
+                            ? Icons.question_mark
+                            : value.passed!
+                                ? Icons.check
+                                : Icons.error,
+                        color: value.passed == null
+                            ? null
+                            : value.passed!
+                                ? Colors.green
+                                : Colors.red,
+                      ),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            tiamat.Text(value.name),
+                            tiamat.Text.labelLow(
+                              value.description,
+                            )
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/commet/lib/ui/molecules/notification_debugger.dart
+++ b/commet/lib/ui/molecules/notification_debugger.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:commet/client/client.dart';
 import 'package:commet/client/components/push_notification/android/android_notifier.dart';
@@ -168,6 +167,12 @@ class _NotificationDebuggerState extends State<NotificationDebugger> {
             description: "distributor for unified push: $distributor",
             passed: distributor != null));
       }
+    } else {
+      steps.add(_NotificationDebugStep(
+          name: "Google Services Configuration",
+          description:
+              "Checks the current config for Google services notifications: ${preferences.fcmKey.value == null ? "null" : preferences.fcmKey.value!.substring(0, 10) + "..."}",
+          passed: preferences.fcmKey.value != null));
     }
 
     String? pushKey = BuildConfig.ENABLE_GOOGLE_SERVICES

--- a/commet/lib/ui/molecules/notification_debugger.dart
+++ b/commet/lib/ui/molecules/notification_debugger.dart
@@ -183,7 +183,7 @@ class _NotificationDebuggerState extends State<NotificationDebugger> {
     var step = _NotificationDebugStep(
         name: "Has Registered Pusher",
         description:
-            "Tests if the client has registered a push notification service with the homeserver",
+            "Tests if the client has registered a push notification service with the homeserver: ${pusher?.data.url?.host}",
         passed: pusher != null);
 
     steps.add(step);

--- a/commet/lib/ui/molecules/timeline_events/timeline_event_menu.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_event_menu.dart
@@ -448,8 +448,6 @@ class TimelineEventMenu {
           name: "Diagnose Notification",
           icon: Icons.notification_important,
           action: (BuildContext context) async {
-            var room = timeline.room;
-
             AdaptiveDialog.show(context,
                 builder: (context) => NotificationDebugger(
                       event: event,

--- a/commet/lib/ui/molecules/timeline_events/timeline_event_menu.dart
+++ b/commet/lib/ui/molecules/timeline_events/timeline_event_menu.dart
@@ -21,6 +21,7 @@ import 'package:commet/main.dart';
 import 'package:commet/ui/atoms/code_block.dart';
 import 'package:commet/ui/molecules/emoji_picker.dart';
 import 'package:commet/ui/molecules/gif_picker.dart';
+import 'package:commet/ui/molecules/notification_debugger.dart';
 import 'package:commet/ui/navigation/adaptive_dialog.dart';
 import 'package:commet/utils/autofill_utils.dart';
 import 'package:commet/utils/common_strings.dart';
@@ -440,6 +441,21 @@ class TimelineEventMenu {
             }
 
             onActionFinished?.call();
+          },
+        ),
+      if (preferences.developerMode.value)
+        TimelineEventMenuEntry(
+          name: "Diagnose Notification",
+          icon: Icons.notification_important,
+          action: (BuildContext context) async {
+            var room = timeline.room;
+
+            AdaptiveDialog.show(context,
+                builder: (context) => NotificationDebugger(
+                      event: event,
+                      client: timeline.client,
+                      room: timeline.room,
+                    ));
           },
         ),
     ];

--- a/commet/lib/ui/pages/main/main_page.dart
+++ b/commet/lib/ui/pages/main/main_page.dart
@@ -183,6 +183,11 @@ class MainPageState extends State<MainPage> {
 
     EventBus.openRoom.stream.listen(onOpenRoomSignal);
 
+    EventBus.openHomeScreen.stream.listen((_) {
+      clearRoomSelection();
+      clearSpaceSelection();
+    });
+
     EventBus.setFilterClient.stream.listen(setFilterClient);
 
     EventBus.openUserProfile.stream.listen(onOpenUserProfileSignal);

--- a/commet/lib/utils/event_bus.dart
+++ b/commet/lib/utils/event_bus.dart
@@ -39,6 +39,8 @@ class EventBus {
   static StreamController<(String, String, String)> openThread =
       StreamController<(String, String, String)>.broadcast();
 
+  static StreamController<void> openHomeScreen = StreamController.broadcast();
+
   static StreamController<void> closeThread = StreamController.broadcast();
 
   static StreamController<Client?> setFilterClient =
@@ -68,6 +70,9 @@ class EventBus {
   static StreamController<void> openCalendar = StreamController.broadcast();
 
   static StreamController<void> openWidgets = StreamController.broadcast();
+
+  static StreamController<String> onReceivedPushNotificationData =
+      StreamController.broadcast();
 
   static StreamController<void> toggleRoomSidePanel =
       StreamController.broadcast();

--- a/commet/lib/utils/stream_utils.dart
+++ b/commet/lib/utils/stream_utils.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+extension StreamUtils<T> on Stream<T> {
+  Future<T> nextItemAsFuture() {
+    Completer<T> completer = Completer();
+
+    listen(
+      (event) {
+        completer.complete(event);
+      },
+    );
+
+    return completer.future;
+  }
+}


### PR DESCRIPTION
Adds a new debug menu to help track down why your notifications might not be showing up

Also adds a fallback method to help unified push find the correct client id, if one is not supplied by the push server